### PR TITLE
OpenJ9 Add Plugin Groovy-Postbuild

### DIFF
--- a/instances/technology.openj9/jenkins/plugins-list
+++ b/instances/technology.openj9/jenkins/plugins-list
@@ -2,6 +2,7 @@ artifactory
 badge
 copyartifact
 generic-webhook-trigger
+groovy-postbuild
 jira
 job-dsl
 pipeline-utility-steps


### PR DESCRIPTION
- Required to run groovy script post build
  that generates a build summary html table.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>