### PR TITLE
OpenJ9 Add config for Github Plugin

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -527,3 +527,10 @@ unclassified:
   slackNotifier:
     teamDomain: "openj9"
     tokenCredentialId: "515a102c-4eee-4e66-9b05-fee104ea6fc2"
+
+  githubpluginconfig:
+    configs:
+      - name: "GitHub"
+        apiUrl: "https://api.github.com"
+        credentialsId: "ce2c6536-6771-4fae-844e-de0fda7dbcc1"
+        manageHooks: true


### PR DESCRIPTION
- Needed to use the GH Commit Status Setter feature

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>