### PR TITLE
OpenJ9: Add BuildUser plugin

### DIFF
--- a/instances/technology.openj9/jenkins/plugins-list
+++ b/instances/technology.openj9/jenkins/plugins-list
@@ -1,5 +1,6 @@
 artifactory
 badge
+build-user-vars-plugin
 copyartifact
 embeddable-build-status
 generic-webhook-trigger


### PR DESCRIPTION
- Needed to help identify builds when launched by users (Grinders etc)

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>