### PR TITLE
Use "Default" as name to set default git installation

### DIFF
--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -385,5 +385,5 @@ tool:
   {{> tools-maven }}
   git:
     installations:
-    - name: "git"
+    - name: "Default"
       home: "/usr/bin/git"

--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -386,4 +386,4 @@ tool:
   git:
     installations:
     - name: "Default"
-      home: "/usr/bin/git"
+      home: "git"


### PR DESCRIPTION
See https://github.com/jenkinsci/git-client-plugin/blob/master/src/main/java/hudson/plugins/git/GitTool.java#L51

Related discussion: https://bugs.eclipse.org/bugs/show_bug.cgi?id=550075