### PR TITLE
Added test label to Aarch64 machine

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -147,7 +147,7 @@ jenkins:
   - permanent:
       name: "cent7-aarch64-1"
       nodeDescription: "cent7-aarch64-1 - Packet.net CentOS 7 128 GB 2CPU - 147.75.97.122"
-      labelString: "hw.arch.aarch64 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build"
+      labelString: "hw.arch.aarch64 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
Currently the only Aarch64 machine is not able to compile tests, but the
testing label is being added to allow for the option of testing in the
future. The aarch64_linux and aarch64_linux_xl platforms are not included
in the target 'all', and therefore will not be run during the nightly
builds.

Signed-off-by: Colton Mills <millscolt3@gmail.com>