### PR TITLE
adminAddress field has been marked as deprecated in Mailer plugin

### DIFF
--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -360,7 +360,6 @@ unclassified:
     url: {{deployment.url}}
 
   mailer:
-    adminAddress: ci-admin@eclipse.org
     replyToAddress: ci-admin@eclipse.org
     smtpHost: mail.eclipse.org
 


### PR DESCRIPTION
version 1.25, which leads to a JCasC error during startup