### PR TITLE
Add emptyDirVolume for /home/jenkins/ to fix change in Kubernetes plugin

### DIFF
--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -84,6 +84,9 @@ jenkins:
         - configMapVolume:
             configMapName: "known-hosts"
             mountPath: "/home/jenkins/.ssh/"
+        - emptyDirVolume:
+            memory: false
+            mountPath: "/home/jenkins/"
         {{#if maven}}
         - emptyDirVolume:
             memory: false
@@ -181,6 +184,9 @@ jenkins:
         - configMapVolume:
             configMapName: "known-hosts"
             mountPath: "/home/jenkins/.ssh/"
+        - emptyDirVolume:
+            memory: false
+            mountPath: "/home/jenkins/"
         {{#if maven}}
         - emptyDirVolume:
             memory: false
@@ -278,6 +284,9 @@ jenkins:
         - configMapVolume:
             configMapName: "known-hosts"
             mountPath: "/home/jenkins/.ssh/"
+        - emptyDirVolume:
+            memory: false
+            mountPath: "/home/jenkins/"
         {{#if maven}}
         - emptyDirVolume:
             memory: false


### PR DESCRIPTION
introduced in version 1.18.0