### PR TITLE
Use m2-secret-dir secret by default instead of configmap

### DIFF
--- a/build/gen-k8s.sh
+++ b/build/gen-k8s.sh
@@ -52,6 +52,7 @@ gen_resource "statefulset"
 gen_resource "tools-pv"
 gen_resource "known-hosts"
 gen_resource "m2-dir"
+gen_resource "m2-secret-dir"
 
 ## Jenkins CaC config map filling
 echo "# GENERATED FILE - DO NOT EDIT" >> "${target}/configmap-jenkins-config.yml"

--- a/build/k8s-deploy.sh
+++ b/build/k8s-deploy.sh
@@ -66,5 +66,6 @@ oc apply -f "${instance}/target/k8s/route.yml"
 oc apply -f "${instance}/target/k8s/tools-pv.yml"
 oc apply -f "${instance}/target/k8s/known-hosts.yml"
 oc apply -f "${instance}/target/k8s/m2-dir.yml"
+oc apply -f "${instance}/target/k8s/m2-secret-dir.yml"
 
 oc apply -f "${instance}/target/k8s/statefulset.yml"

--- a/templates/default.json.hbs
+++ b/templates/default.json.hbs
@@ -113,9 +113,13 @@
     "home": "/home/jenkins/.m2",
     "files": {
       "settings.xml": {
-        "volumeType": "ConfigMap",
-        "volumeName": "m2-dir"
-      }, 
+        "volumeType": "Secret",
+        "volumeName": "m2-secret-dir"
+      },
+      "settings-security.xml": {
+        "volumeType": "Secret",
+        "volumeName": "m2-secret-dir"
+      },
       "toolchains.xml": {
         "volumeType": "ConfigMap",
         "volumeName": "m2-dir"

--- a/templates/k8s/m2-dir.yml.hbs
+++ b/templates/k8s/m2-dir.yml.hbs
@@ -5,18 +5,6 @@ metadata:
   {{> common-metadata }}
   name: m2-dir
 data:
-  settings.xml: |
-    <?xml version="1.0" encoding="UTF-8"?>
-    <settings>
-      <mirrors>
-        <mirror>
-          <id>eclipse.maven.central.mirror</id>
-          <name>Eclipse Central Proxy</name>
-          <url>https://repo.eclipse.org/content/repositories/maven_central/</url>
-          <mirrorOf>central</mirrorOf>
-        </mirror>
-      </mirrors>
-    </settings>
   toolchains.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
     <toolchains>

--- a/templates/k8s/m2-secret-dir.yml.hbs
+++ b/templates/k8s/m2-secret-dir.yml.hbs
@@ -1,0 +1,21 @@
+{{> copyright }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{> common-metadata }}
+  name: m2-secret-dir
+stringData:
+  settings.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings>
+      <mirrors>
+        <mirror>
+          <id>eclipse.maven.central.mirror</id>
+          <name>Eclipse Central Proxy</name>
+          <url>https://repo.eclipse.org/content/repositories/maven_central/</url>
+          <mirrorOf>central</mirrorOf>
+        </mirror>
+      </mirrors>
+    </settings>
+  settings-security.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This fixes the issue that projects can't deploy to repo.eclipse.org or
OSSRH from the default pod templates.

toolchains.xml is still kept in m2-dir config map.
settings-security.xml is pre-filled with a XML header only.