### PR TITLE
Update Maven 3.6.x to 3.6.2

### DIFF
--- a/templates/jenkins/partials/tools-maven.hbs
+++ b/templates/jenkins/partials/tools-maven.hbs
@@ -2,8 +2,8 @@ maven:
   installations:
   - name: "apache-maven-latest"
     home: "/opt/tools/apache-maven/latest"
-  - name: "apache-maven-3.6.1"
-    home: "/opt/tools/apache-maven/3.6.1"
+  - name: "apache-maven-3.6.2"
+    home: "/opt/tools/apache-maven/3.6.2"
   - name: "apache-maven-3.5.4"
     home: "/opt/tools/apache-maven/3.5.4"
   - name: "apache-maven-3.3.9"


### PR DESCRIPTION
Maven 3.6.2 is now available [1] and fixes the issues with Tycho builds
which were reported by many Eclipse projects, see bug 546463.

[1] https://maven.apache.org/docs/3.6.2/release-notes.html

Bug: 546463
Signed-off-by: Matthias Sohn <matthias.sohn@sap.com>