### PR TITLE
[emft.mwe] Add parameterized-scheduler plugin

### DIFF
--- a/instances/modeling.emf.mwe/jenkins/plugins-list
+++ b/instances/modeling.emf.mwe/jenkins/plugins-list
@@ -1,1 +1,2 @@
 slack
+parameterized-scheduler


### PR DESCRIPTION
The MWE build needs parametrized cron triggers.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>