### PR TITLE
Temporarily remove build label form aix 5,6

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -70,7 +70,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-5"
       nodeDescription: "openj9_ci_5 - l490vp082_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -89,7 +89,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-6"
       nodeDescription: "openj9_ci_6 - l490vp082_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
- Machines are still being configured and are
  failing when compiles land on them.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>