### PR TITLE
OpenJ9: RH7 s390 and AIX machine updates

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -20,13 +20,13 @@ jenkins:
       name: "aix71-p8-2"
       nodeDescription: "openj9_ci_2 - l490vp018_pub - AIX PPC64"
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
-      remoteFS: '/home/u0020236/'
+      remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
       launcher:
         command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix u0020236@172.29.157.108 'rm -f slave.jar ; wget -O slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix jenkins@172.29.156.83 'rm -f slave.jar ; wget -O slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
       nodeProperties:
       - envVars:
           env:
@@ -36,13 +36,13 @@ jenkins:
       name: "aix71-p8-3"
       nodeDescription: "openj9_ci_3 - l490vp027_pub - AIX PPC64"
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
-      remoteFS: '/home/u0020236/'
+      remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
       launcher:
         command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix u0020236@172.29.155.67 'wget -O slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix jenkins@172.29.155.138 'wget -O slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
       nodeProperties:
       - envVars:
           env:
@@ -52,21 +52,18 @@ jenkins:
       name: "aix71-p8-4"
       nodeDescription: "openj9_ci_4 - l490vp041_pub - AIX PPC64"
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
-      remoteFS: '/home/u0020236/'
+      remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
       launcher:
         command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix u0020236@172.29.156.34 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix jenkins@172.29.155.137 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
       nodeProperties:
       - envVars:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/home/u0020236/lib/perl5"
   - permanent:
       name: "aix71-p8-5"
       nodeDescription: "openj9_ci_5 - l490vp082_pub - AIX PPC64"
@@ -83,28 +80,22 @@ jenkins:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "aix71-p8-6"
       nodeDescription: "openj9_ci_6 - l490vp082_pub - AIX PPC64"
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.test"
-      remoteFS: '/home/u0020236/'
+      remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
       launcher:
         command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix u0020236@172.29.156.119 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix jenkins@172.29.153.171 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
       nodeProperties:
       - envVars:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "aix71-p8-7"
       nodeDescription: "openj9_ci_7 - l490vp083_pub - AIX PPC64"
@@ -121,9 +112,6 @@ jenkins:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "aix71-p8-8"
       nodeDescription: "openj9_ci_8 - l490vp084_pub - AIX PPC64"
@@ -140,9 +128,6 @@ jenkins:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "aix71-p8-9"
       nodeDescription: "openj9_ci_9 - l490vp086_pub - AIX PPC64"
@@ -159,28 +144,22 @@ jenkins:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "aix71-p8-10"
       nodeDescription: "openj9_ci_10 - l490vp087_pub - AIX PPC64"
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.test"
-      remoteFS: '/home/u0020236/'
+      remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
       launcher:
         command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix u0020236@172.29.157.145 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@140.211.168.230 \"ssh -i ~/.ssh/id_rsa.aix jenkins@172.29.156.189 'wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -Xshareclasses:none -Xdump:none -jar slave.jar'\""
       nodeProperties:
       - envVars:
           env:
           - key: "LDR_CNTRL"
             value: "MAXDATA=0x80000000"
-          env:
-          - key: "PERL5LIB"
-            value: "/opt/freeware/lib/perl5"
   - permanent:
       name: "cent6-x64-1"
       nodeDescription: "cent6-x64-1 - UNB CentOS 6 8 GB 4CPU - 192.168.10.188"

--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -391,6 +391,50 @@ jenkins:
         command:
           command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@148.100.113.63 \"wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -jar slave.jar\""
   - permanent:
+      name: "ub16-390-5"
+      nodeDescription: "Linux 390 Red Hat 7. 4CPU 8GB Ram  91GB Disk"
+      labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.redhat sw.os.redhat.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
+      remoteFS: '/home/jenkins'
+      numExecutors: 1
+      mode: EXCLUSIVE
+      retentionStrategy: "always"
+      launcher:
+        command:
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@148.100.245.9 \"wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -jar slave.jar\""
+  - permanent:
+      name: "ub16-390-6"
+      nodeDescription: "Linux 390 Red Hat 7. 4CPU 8GB Ram  91GB Disk"
+      labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.redhat sw.os.redhat.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
+      remoteFS: '/home/jenkins'
+      numExecutors: 1
+      mode: EXCLUSIVE
+      retentionStrategy: "always"
+      launcher:
+        command:
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@148.100.244.2 \"wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -jar slave.jar\""
+  - permanent:
+      name: "ub16-390-7"
+      nodeDescription: "Linux 390 Red Hat 7. 4CPU 8GB Ram  91GB Disk"
+      labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.redhat sw.os.redhat.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
+      remoteFS: '/home/jenkins'
+      numExecutors: 1
+      mode: EXCLUSIVE
+      retentionStrategy: "always"
+      launcher:
+        command:
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@148.100.244.25 \"wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -jar slave.jar\""
+  - permanent:
+      name: "ub16-390-8"
+      nodeDescription: "Linux 390 Red Hat 7. 4CPU 8GB Ram  91GB Disk"
+      labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.redhat sw.os.redhat.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
+      remoteFS: '/home/jenkins'
+      numExecutors: 1
+      mode: EXCLUSIVE
+      retentionStrategy: "always"
+      launcher:
+        command:
+          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.openj9 jenkins@148.100.245.61 \"wget -qO slave.jar https://ci.eclipse.org/openj9/jnlpJars/slave.jar ; exec java -jar slave.jar\""
+  - permanent:
       name: "ub16p8j91"
       nodeDescription: "ub16p8j91 - UNB Ubuntu 16 p8le"
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"


### PR DESCRIPTION
Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>

These machines will need to be disabled once the change is deployed as there is a corresponding change that needs to also merge at eclipse/openj9 before they can be made active.

fyi @pshipton 

EDIT: this is the OpenJ9 dependent PR that needs to go second.
https://github.com/eclipse/openj9/pull/8601