### PR TITLE
Fix issue with missing repository name for defaultImage

### DIFF
--- a/templates/k8s/statefulset.libsonnet
+++ b/templates/k8s/statefulset.libsonnet
@@ -122,7 +122,7 @@ local Kube = import "kube.libsonnet";
                     "-DexecutableWar.jetty.sessionIdCookieName=JSESSIONID." + config.project.shortName,
                     "-Dcasc.jenkins.config=/etc/jenkins/jenkins.yaml",
                     "-Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=5000",
-                    "-Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=%s:%s" % [defaultJnlpAgent.docker.image.name, defaultJnlpAgent.docker.image.tag],
+                    "-Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=%s/%s:%s" % [defaultJnlpAgent.docker.repository, defaultJnlpAgent.docker.image.name, defaultJnlpAgent.docker.image.tag],
                     "-Dorg.csanchez.jenkins.plugins.kubernetes.PodTemplate.connectionTimeout=" + config.jenkins.agentConnectionTimeout,
                     "-Dkubernetes.websocket.ping.interval=30000",
                     ])


### PR DESCRIPTION
-Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage

Error was:
ERROR: Unable to pull Docker image "basic-agent:3.35".
Check if image tag name is spelled correctly.