### PR TITLE
OpenJ9: Add build and test labels to new AIX machines

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -3,7 +3,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-1"
       nodeDescription: "openj9_ci_1 - l490vp054_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -19,7 +19,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-2"
       nodeDescription: "openj9_ci_2 - l490vp018_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -35,7 +35,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-3"
       nodeDescription: "openj9_ci_3 - l490vp027_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -51,7 +51,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-4"
       nodeDescription: "openj9_ci_4 - l490vp041_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -67,7 +67,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-5"
       nodeDescription: "openj9_ci_5 - l490vp082_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -83,7 +83,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-6"
       nodeDescription: "openj9_ci_6 - l490vp082_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -99,7 +99,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-7"
       nodeDescription: "openj9_ci_7 - l490vp083_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -115,7 +115,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-8"
       nodeDescription: "openj9_ci_8 - l490vp084_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -131,7 +131,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-9"
       nodeDescription: "openj9_ci_9 - l490vp086_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/u0020236/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -147,7 +147,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-10"
       nodeDescription: "openj9_ci_10 - l490vp087_pub - AIX PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -163,7 +163,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-11"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -185,7 +185,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-12"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -207,7 +207,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-13"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -229,7 +229,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-14"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -251,7 +251,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-15"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -273,7 +273,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-16"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -295,7 +295,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-17"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -317,7 +317,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-18"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -339,7 +339,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-19"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -361,7 +361,7 @@ jenkins:
   - permanent:
       name: "aix71-p8-20"
       nodeDescription: "AIX 7.1 PPC64"
-      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp"
+      labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
* remove build and test labels from old AIX machines

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>