### PR TITLE
[iot.ditto] Add pipeline utility steps plugin and configure Git plugin

### DIFF
--- a/instances/iot.ditto/jenkins/configuration.yml
+++ b/instances/iot.ditto/jenkins/configuration.yml
@@ -8,3 +8,8 @@ tool:
           - nodeJSInstaller:
               id: "10.18.1"
               npmPackagesRefreshHours: 72
+unclassified:
+  gitscm:
+    globalConfigName: Eclipse Ditto committers
+    globalConfigEmail: ditto-dev@eclipse.org
+    createAccountBasedOnEmail: false

--- a/instances/iot.ditto/jenkins/plugins-list
+++ b/instances/iot.ditto/jenkins/plugins-list
@@ -1,1 +1,2 @@
 nodejs
+pipeline-utility-steps


### PR DESCRIPTION
Hi,
today was the first time we tried to release our JavaScript client since we switched to a jiro instance. We noticed, that we're missing the Pipeline utility steps plugin and configuration for the Git plugin. I added both in this PR. 