### PR TITLE
instanceCap should not be set, setting containerCapStr should be enough

### DIFF
--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -68,7 +68,7 @@ jenkins:
           ttyEnabled: true
           command: ""
           args: ""
-        instanceCap: 5
+        instanceCap: ""
         name: "{{@key}}"
         namespace: "{{../namespace}}"
         nodeUsageMode: {{this.mode}}


### PR DESCRIPTION
`instanceCap` will limit the number of concurrently running pod templates even if `containerCapStr` is higher.  `instanceCap` can never exceed `containerCapStr` though. So it should be either set to the same value as `containerCapStr` or not be set at all.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=563363 for an example
where this caused issues.