### PR TITLE
Add node affinity for Jenkins master instances

### DIFF
--- a/templates/k8s/statefulset.libsonnet
+++ b/templates/k8s/statefulset.libsonnet
@@ -18,6 +18,24 @@ local Kube = import "kube.libsonnet";
         },
         spec: {
           serviceAccountName: config.project.shortName,
+          affinity: {
+            nodeAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  weight: 1,
+                  preference: {
+                    matchExpressions: [
+                      {
+                        key: "speed",
+                        operator: "NotIn",
+                        values: ["fast"]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
           terminationGracePeriodSeconds: 1200,
           containers: [
             {


### PR DESCRIPTION
Master pods should not be scheduled on nodes with label "speed=fast".