### PR TITLE
Improved open_jipps_in_browser.sh

### DIFF
--- a/incubation/open_jipps_in_browser.sh
+++ b/incubation/open_jipps_in_browser.sh
@@ -6,29 +6,25 @@ set -o nounset
 set -o pipefail
 
 IFS=$'\n\t'
-script_name="$(basename ${0})"
-script_folder="$(dirname $(readlink -f "${0}"))"
-
-default_host="ci.eclipse.org"
+#script_name="$(basename "${BASH_SOURCE[0]}")"
+script_folder="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 open_url() {
   local url=$1
-  if which xdg-open > /dev/null; then
-    xdg-open ${url}
+  if which xdg-open > /dev/null; then # most Linux
+    xdg-open "${url}"
+  elif which open > /dev/null; then # macOS
+    open "${url}"
   fi
 }
 
-for f in ${@}
-do
-  project_name="$(basename ${f})"
+for f in "${@}"; do
+  project_name="$(basename "${f}")"
   short_name=${project_name##*.}
   echo "${short_name}"
-  if [[ $(grep -e '"host": "ci-staging.eclipse.org"' ../instances/${project_name}/config.jsonnet) ]]; then
-    host="ci-staging.eclipse.org"
-  else
-    host="${default_host}"
-  fi
-  open_url "https://${host}/${short_name}"
+  url="$(jsonnet "${script_folder}/../instances/${project_name}/jiro.jsonnet" | jq -r '.["config.json"].deployment.url')"
+  
+  open_url "${url}"
 done 
 # check if staging or not
 # check if project name or short name


### PR DESCRIPTION
* Support macOS (open vs xdg-open)
* Less heuristics for URL, read and filter the  instance config
* Happy shellchecks