### PR TITLE
Add 'warnings' plugin to JDT JIPP plugin configuration.

### DIFF
--- a/instances/eclipse.jdt/jenkins/plugins-list
+++ b/instances/eclipse.jdt/jenkins/plugins-list
@@ -1,0 +1,1 @@
+warnings-ng


### PR DESCRIPTION
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=565280
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>