### PR TITLE
Add cobertura plugin for code coverage

### DIFF
--- a/instances/iot.kuksa/jenkins/plugins-list
+++ b/instances/iot.kuksa/jenkins/plugins-list
@@ -1,2 +1,3 @@
 xunit
 embeddable-build-status
+cobertura


### PR DESCRIPTION
Add cobertura plugin to Eclipse kuksa  CI to enable code coverage tests in https://github.com/eclipse/kuksa.val/pull/85