### PR TITLE
OpenJ9: Change labels on worker-3

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -924,7 +924,7 @@ jenkins:
   - permanent:
       name: "worker-3"
       nodeDescription: "UNB Artifactory"
-      labelString: "worker ci.geo.unb"
+      labelString: "artifactory ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
* worker-3 system needs to be used exclusively for artifactory activities

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>