### PR TITLE
[Xtext] Add build-user-vars-plugin

### DIFF
--- a/instances/modeling.tmf.xtext/config.jsonnet
+++ b/instances/modeling.tmf.xtext/config.jsonnet
@@ -16,6 +16,7 @@
       "parameterized-scheduler",
       "show-build-parameters",
       "slack",
+      "build-user-vars-plugin"
     ],
   },
   gradle+: {


### PR DESCRIPTION
We would like to use the current user for committing automatic changes triggered by releng jobs. Currently we enter that by parameters.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>