### PR TITLE
Change all nodes to mode NORMAL

### DIFF
--- a/instances/technology.openj9/jenkins/configuration.yml
+++ b/instances/technology.openj9/jenkins/configuration.yml
@@ -6,7 +6,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -28,7 +28,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -50,7 +50,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -72,7 +72,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -94,7 +94,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -116,7 +116,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -138,7 +138,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -160,7 +160,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -182,7 +182,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -204,7 +204,7 @@ jenkins:
       labelString: "hw.arch.ppc64 sw.os.aix sw.os.aix.7_1 ci.geo.ibmpdp ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -226,7 +226,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.geo.unb ci.role.test ci.role.build"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -237,7 +237,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.role.test ci.role.build ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -248,7 +248,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.role.test ci.role.build ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -259,7 +259,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.role.test ci.role.build ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -270,7 +270,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.geo.unb ci.role.test ci.role.build"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -281,7 +281,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.role.test ci.role.build ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -292,7 +292,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.6 ci.role.test ci.role.build ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -303,7 +303,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -314,7 +314,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -325,7 +325,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -336,7 +336,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -347,7 +347,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -358,7 +358,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.linux sw.os.cent sw.os.cent.7 ci.role.test ci.role.build ci.geo.unb sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -380,7 +380,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_11 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -391,7 +391,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_11 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -402,7 +402,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_13 ci.role.build ci.geo.unb ci.role.test"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -413,7 +413,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_13 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -424,7 +424,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_14 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -435,7 +435,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_14 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -446,7 +446,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.osx sw.os.osx.10_14 ci.role.build ci.role.test ci.geo.unb"
       remoteFS: '/Users/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -457,7 +457,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -468,7 +468,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -479,7 +479,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -490,7 +490,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -501,7 +501,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.rhel sw.os.rhel.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -512,7 +512,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.rhel sw.os.rhel.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -523,7 +523,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.rhel sw.os.rhel.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -534,7 +534,7 @@ jenkins:
       labelString: "hw.arch.s390x hw.arch.s390x.z15 sw.os.linux sw.os.rhel sw.os.rhel.7 ci.role.build ci.role.test sw.tool.docker ci.geo.marist"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -545,7 +545,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -556,7 +556,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -567,7 +567,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -578,7 +578,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -589,7 +589,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -600,7 +600,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.cent sw.os.cent.7 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -611,7 +611,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -622,7 +622,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -633,7 +633,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -644,7 +644,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -655,7 +655,7 @@ jenkins:
       labelString: "hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 sw.tool.docker ci.geo.osu ci.role.build ci.role.test"
       remoteFS: '/home/jenkins/jenkins-agent'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -666,7 +666,7 @@ jenkins:
       labelString: "hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker ci.geo.osu"
       remoteFS: '/home/jenkins/jenkins-agent'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -677,7 +677,7 @@ jenkins:
       labelString: "hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker ci.geo.osu"
       remoteFS: '/home/jenkins/jenkins-agent'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -688,7 +688,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -699,7 +699,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.ppc64le sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -710,7 +710,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.tool.docker sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.test ci.role.build"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -721,7 +721,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.test sw.tool.docker ci.role.build"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -732,7 +732,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.test sw.tool.docker ci.role.build"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -743,7 +743,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test sw.tool.docker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -754,7 +754,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -765,7 +765,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.tool.docker sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -776,7 +776,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.tool.docker sw.os.linux sw.os.ubuntu sw.os.ubuntu.16 ci.role.build ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -787,7 +787,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.tool.docker sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -798,7 +798,7 @@ jenkins:
       labelString: "ci.geo.unb hw.arch.x86 sw.tool.docker sw.os.linux sw.os.ubuntu sw.os.ubuntu.18 ci.role.test"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -809,7 +809,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -825,7 +825,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -841,7 +841,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -857,7 +857,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -873,7 +873,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -889,7 +889,7 @@ jenkins:
       labelString: "hw.arch.x86 sw.os.windows sw.os.windows.2012 ci.geo.softlayer ci.role.build ci.role.test"
       remoteFS: 'F:\Users\jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -905,7 +905,7 @@ jenkins:
       labelString: "docker proxy worker ci.geo.osu proxy artifactory"
       remoteFS: '/home/jenkins/jenkins-agent'
       numExecutors: 3
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -916,7 +916,7 @@ jenkins:
       labelString: "docker worker ci.geo.osu"
       remoteFS: '/home/jenkins/jenkins-agent'
       numExecutors: 3
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:
@@ -927,7 +927,7 @@ jenkins:
       labelString: "artifactory ci.geo.unb"
       remoteFS: '/home/jenkins'
       numExecutors: 1
-      mode: EXCLUSIVE
+      mode: NORMAL
       retentionStrategy: "always"
       launcher:
         command:


### PR DESCRIPTION
Instead of 'Only build jobs with label
expressions matching this node' change
to 'Use this node as much as possible'.

This change was triggered because the test
jobs in post-parallel step now look for
'any' node. Which means they won't land on
any EXCLUSIVE node. The jobs have started
triggering the kubernetes cloud agents
to be provisioned.

Note: I left aarch64 as is because we only
have one machine for that platform.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>