### PR TITLE
[iot.ditto] Update installed NodeJs version

### DIFF
--- a/instances/iot.ditto/jenkins/configuration.yml
+++ b/instances/iot.ditto/jenkins/configuration.yml
@@ -6,7 +6,7 @@ tool:
       - installSource:
           installers:
           - nodeJSInstaller:
-              id: "10.18.1"
+              id: "14.16.1"
               npmPackagesRefreshHours: 72
 unclassified:
   gitscm:


### PR DESCRIPTION
Updates the installed NodeJs version as a) the Ditto JavaScript client build requires features of NodeJs > 10 and b) NodeJs 10 has its maintenance EOL end of this month.