### PR TITLE
Solaris set GIT_SSH to use OpenCSW version of openssh

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -87,6 +87,8 @@ jenkins:
           env:
           - key: "PATH"
             value: "/opt/csw/bin:/usr/bin:/bin:/usr/local/bin"
+          - key: "GIT_SSH"
+            value: "/opt/csw/bin/ssh"
   - permanent:
       name: "jck-ibm-aix71-ppc64-1"
       nodeDescription: "AIX 7.1 machine hosted by IBM Garage"


### PR DESCRIPTION
Fixes: 

```bash
bash-3.2# ssh -T git@github.com
Client and server could not agree on a key exchange algorithm:
  client: diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
  server: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
```