### PR TITLE
add /usr/sbin to PATH on Solaris

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -86,7 +86,7 @@ jenkins:
       - envVars:
           env:
           - key: "PATH"
-            value: "/opt/csw/bin:/usr/bin:/bin:/usr/local/bin"
+            value: "/opt/csw/bin:/usr/bin:/bin:/usr/local/bin:/usr/sbin"
           - key: "GIT_SSH"
             value: "/opt/csw/bin/ssh"
   - permanent:


### PR DESCRIPTION
the test scripts need `psrinfo` which is in /usr/sbin