### PR TITLE
Add embeddable-build-status plugin to OMR

### DIFF
--- a/instances/technology.omr/config.jsonnet
+++ b/instances/technology.omr/config.jsonnet
@@ -29,6 +29,7 @@ local permissionsTemplates = import '../../templates/permissions.libsonnet';
       },
     ],
     plugins+: [
+      "embeddable-build-status",
       "envinject",
       "generic-webhook-trigger",
       "gradle",


### PR DESCRIPTION
It is expected by https://github.com/eclipse/omr/README.md.