### PR TITLE
Add embeddable-build-status for Theia

### DIFF
--- a/instances/ecd.theia/config.jsonnet
+++ b/instances/ecd.theia/config.jsonnet
@@ -5,6 +5,7 @@
   },
   jenkins+: {
     plugins+: [
+      "embeddable-build-status",
       "mail-watcher-plugin",
       "pipeline-utility-steps",
     ],


### PR DESCRIPTION
For https://github.com/eclipse-theia/theia-blueprint/issues/163 we would like to show a status badge for builds on the Github page. 
Therefore we would like to install the "embeddable-build-status" plugin