### PR TITLE
Change name to match other Jenkins config

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -593,7 +593,7 @@ unclassified:
   globalLibraries:
     libraries:
     - defaultVersion: "master"
-      name: "jenkins-helper"
+      name: "openjdk-jenkins-helper"
       retriever:
         modernSCM:
           scm:


### PR DESCRIPTION
Existing groovy scripts and many other Jenkins servers using said groovy scripts use the name 'openjdk-jenkins-helper'
Change name in config here to match.

Signed-off-by: Shelley Lambert <slambert@gmail.com>