### PR TITLE
docs: change link to yq tool repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Scale down to 0 the StatefulSet running Jenkins then scale it up to 1. It makes 
 * [bash 4](https://www.gnu.org/software/bash/)
 * [jsonnet](https://github.com/google/jsonnet/)
 * [jq](https://stedolan.github.io/jq/)
-* [yq](https://mikefarah.github.io/yq/)
+* [yq](https://github.com/mikefarah/yq/)
 * [hbs-cli](https://www.npmjs.com/package/hbs-cli)
 
       $ npm i -g hbs-cli


### PR DESCRIPTION
yq tool repository seems to have change, the original link show a 404 page.  