### PR TITLE
Update default version of jenkins-pipeline-library

### DIFF
--- a/instances/foundation-internal.webdev/jenkins/configuration.yml
+++ b/instances/foundation-internal.webdev/jenkins/configuration.yml
@@ -51,7 +51,7 @@ unclassified:
       cachingConfiguration:
         excludedVersionsStr: "main"
         refreshTimeMinutes: 1440
-      defaultVersion: "refs/tags/v0.9.7"
+      defaultVersion: "refs/tags/v0.9.8"
       retriever:
         modernSCM:
           scm:


### PR DESCRIPTION
Fix for https://gitlab.eclipse.org/eclipsefdn/it/releng/jenkins-pipeline-library/-/issues/3. Note that the runtime configuration has already been edited via the UI.