### PR TITLE
Decommissioning of old Marist s390x systems

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -28,40 +28,6 @@ jenkins:
             manuallyProvidedKeyVerificationStrategy:
               key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC6AZ52BYtn9IHiTNleFhxPuzfVZ62i8OaRJVvCzheTU2mRePox9ipTv3V/okLuMRtD01gpXQpqax3CqaiSpc+bw/8Utcoe3zQaIEX61bvC6lA5eLN60662z3LH1Mf/QxYb2BNSRjvMtzK5+QnbHQJIX1091kOCu/0KLPrgd78ItYnZj3ZMUUWCycjQwsxcJPLNDL7oKBAkNwIjVfD5cPJMIkatTD7Li82E3rNfg/mfshTvdzHzkxryaIx9G9KwmdXtgWiWH4ZVpz3TvadZITyTy67PFbQrClVN+EOPw8jg0n4aMOckc6+Dk8bsDzwWIm2KuTP3BCU3U/VHSK3u7BKhY0tBw88x4jXmZuT+UASLSFFfyUMwHJYjiUuev8FYwVdxy1z5ZMnjaEq/ovemliRBRpOUdgKpegiLxsUZ8hJRwRX5rAD/74nJdMRdtDYYq74lrdcddakyyfxR0lq8/i9AV+kXTEgBCmZeGDXfgFFKb/3GXnnevST0szUnm/ZSkRk="
   - permanent:
-      name: "jck-marist-ubuntu2004-s390x-1"
-      nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-      labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-      remoteFS: '/home/jenkins'
-      numExecutors: 1
-      mode: EXCLUSIVE
-      retentionStrategy: "always"
-      launcher:
-        ssh:
-          host: "148.100.84.95"
-          port: "22"
-          credentialsId: "jenkins-jck-ssh"
-          javaPath: ""
-          sshHostKeyVerificationStrategy:
-            manuallyProvidedKeyVerificationStrategy:
-              key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK0XaYiD+TSQoEmNoJ4TJl8yWUnYSqdLezQTU7RvqiqZUr7y2Fj0kcV1oP8j0+PgBDhEv3pl3zBQeHPlFeomcAb7by0M9GAkrM24tA/Vjld5Nmceagqnabv9Q/lpz2Bi+ke0rOirMI5Ekv/Y5HDf8Sr9AfRvPpvwCwXR0kugssr3+gvetjKQBYJil2IBcsaAEW/yuHFV2W5r9TowjLvORvTYCN5bGNlDye1YBwzs5y0YslgdS8wObsaeExZH57mnQ79nEljPWVIP5gzfraunRX4iGEtOJxEL2O02j58LelbTxaHlL13o89n6M0N8dyqwNwKlOv/LPsmKC0oEA/aPEbHirzDyxNYcTuS4or4F5AyGrjr8mQYiWep93hiJand1Mymrb8XsHNV2qwQRZrNP1IHZ4IaKuI7PJYzyfEA/ksDgrGOoAbc5Aj6QWaG1ep//XvYKPzyWeR8SDV68f/Avobt5nmqEHyeYFfjcfDpDZQvdP2SUtRPa++iD2BQsMsc1M="
-  - permanent:
-      name: "jck-marist-ubuntu2004-s390x-2"
-      nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-      labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-      remoteFS: '/home/jenkins'
-      numExecutors: 1
-      mode: EXCLUSIVE
-      retentionStrategy: "always"
-      launcher:
-        ssh:
-          host: "148.100.84.175"
-          port: "22"
-          credentialsId: "jenkins-jck-ssh"
-          javaPath: ""
-          sshHostKeyVerificationStrategy:
-            manuallyProvidedKeyVerificationStrategy:
-              key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDCSTNTGL3mf3dBPWjkBF2JgQceXIyuTmyXhxvFPzSXn8wFmG9Nz09L0jLyfL5NtbN4nZe65fc7/bhfo4bnr9PmDTcIldW7Y59ScTC3ink9YNYiRJpYsuJ14T0scLHPfb6rRv6MpRGsulGL0dnbbPAJE8RQ9om1JEid/unE/IpbCgfuodQQ0wjVxwc5UpcmJ8G2/spuW8QApZzVUqaUyiBSDtOnczBXcdOIX1t74RN9jf1sxVzjjEfjatQkgK7hnHFczAJPBGOQgApVYWKi/bKKtlT0w3XwdaFw9l5a5+JyKogpmR2EjG9Je3Vy2S4ZhvpMGat0mudOeoE9zvIhSCNPkX0NYyF8BdCqAaky33tXZH+XnM3XAaqGZLADn+RmLvKx2ZyFU9VFGkd0gscljCi8etvBGE7+ZbSZLa8LCydvDedzLM+2HhRraR758cV0r51Rv7DqRfH2DAjZA76KKeHRA9NrRbMKisbYvzxC8GnJb/BOxBp942usQqpa0HZBczM="
-  - permanent:
       name: "jck-marist-ubuntu2004-s390x-3"
       nodeDescription: "2-core 4Gb zLinux machine hosted at Marist"
       labelString: "ci.role.test hw.arch.s390x sw.os.linux"
@@ -96,23 +62,6 @@ jenkins:
           sshHostKeyVerificationStrategy:
             manuallyProvidedKeyVerificationStrategy:
               key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPgLhlW7LdMg6VRkyl4trVUWvUvHD92264xtC7rgFe8s"
-  - permanent:
-      name: "jck-marist-rhel7-s390x-1"
-      nodeDescription: "2-core 4Gb zLinux machine hosted at Marist Cloud"
-      labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-      remoteFS: '/home/jenkins'
-      numExecutors: 1
-      mode: EXCLUSIVE
-      retentionStrategy: "always"
-      launcher:
-        ssh:
-          host: "148.100.84.144"
-          port: "22"
-          credentialsId: "jenkins-jck-ssh"
-          javaPath: ""
-          sshHostKeyVerificationStrategy:
-            manuallyProvidedKeyVerificationStrategy:
-              key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBCQ3k2UtFTNTPZDpbyjwuwodCW3iZ5v45naMsVnVbW665eYuanAAL9cCvCLQONUDwmacvKw5sAQlWH6xeNVxxSJTUPdAFrg00rLi23VKqX/rYKjqbcRrUEx/cXgQ25SEVRys+T4onH0mu0Eww2s5rMPWf9qbhEVKkaMIJDm4VPsRIs4bJQoDqd0wqEYlnksmNd1aecYoWtcF8/h5ce8w8iNITTfX+c8uTPSsveadOge11EZIc1uFoX1vfwcq5Ne4dchheH1RuBPFVoZETAuxCIgomcYaXn3TOr+5EIAfA6C8x5yEAuUJ+Yme59gLozBUHZV+SaEu4K5kSLf3dohyH"
   - permanent:
       name: "jck-marist-rhel7-s390x-2"
       nodeDescription: "2-core 4Gb machine hosted at Marist Cloud"

--- a/instances/adoptium.temurin-compliance/target/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/target/jenkins/configuration.yml
@@ -344,40 +344,6 @@ jenkins:
               manuallyProvidedKeyVerificationStrategy:
                 key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC6AZ52BYtn9IHiTNleFhxPuzfVZ62i8OaRJVvCzheTU2mRePox9ipTv3V/okLuMRtD01gpXQpqax3CqaiSpc+bw/8Utcoe3zQaIEX61bvC6lA5eLN60662z3LH1Mf/QxYb2BNSRjvMtzK5+QnbHQJIX1091kOCu/0KLPrgd78ItYnZj3ZMUUWCycjQwsxcJPLNDL7oKBAkNwIjVfD5cPJMIkatTD7Li82E3rNfg/mfshTvdzHzkxryaIx9G9KwmdXtgWiWH4ZVpz3TvadZITyTy67PFbQrClVN+EOPw8jg0n4aMOckc6+Dk8bsDzwWIm2KuTP3BCU3U/VHSK3u7BKhY0tBw88x4jXmZuT+UASLSFFfyUMwHJYjiUuev8FYwVdxy1z5ZMnjaEq/ovemliRBRpOUdgKpegiLxsUZ8hJRwRX5rAD/74nJdMRdtDYYq74lrdcddakyyfxR0lq8/i9AV+kXTEgBCmZeGDXfgFFKb/3GXnnevST0szUnm/ZSkRk="
     - permanent:
-        name: "jck-marist-ubuntu2004-s390x-1"
-        nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-        labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-        remoteFS: '/home/jenkins'
-        numExecutors: 1
-        mode: EXCLUSIVE
-        retentionStrategy: "always"
-        launcher:
-          ssh:
-            host: "148.100.84.95"
-            port: "22"
-            credentialsId: "jenkins-jck-ssh"
-            javaPath: ""
-            sshHostKeyVerificationStrategy:
-              manuallyProvidedKeyVerificationStrategy:
-                key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK0XaYiD+TSQoEmNoJ4TJl8yWUnYSqdLezQTU7RvqiqZUr7y2Fj0kcV1oP8j0+PgBDhEv3pl3zBQeHPlFeomcAb7by0M9GAkrM24tA/Vjld5Nmceagqnabv9Q/lpz2Bi+ke0rOirMI5Ekv/Y5HDf8Sr9AfRvPpvwCwXR0kugssr3+gvetjKQBYJil2IBcsaAEW/yuHFV2W5r9TowjLvORvTYCN5bGNlDye1YBwzs5y0YslgdS8wObsaeExZH57mnQ79nEljPWVIP5gzfraunRX4iGEtOJxEL2O02j58LelbTxaHlL13o89n6M0N8dyqwNwKlOv/LPsmKC0oEA/aPEbHirzDyxNYcTuS4or4F5AyGrjr8mQYiWep93hiJand1Mymrb8XsHNV2qwQRZrNP1IHZ4IaKuI7PJYzyfEA/ksDgrGOoAbc5Aj6QWaG1ep//XvYKPzyWeR8SDV68f/Avobt5nmqEHyeYFfjcfDpDZQvdP2SUtRPa++iD2BQsMsc1M="
-    - permanent:
-        name: "jck-marist-ubuntu2004-s390x-2"
-        nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-        labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-        remoteFS: '/home/jenkins'
-        numExecutors: 1
-        mode: EXCLUSIVE
-        retentionStrategy: "always"
-        launcher:
-          ssh:
-            host: "148.100.84.175"
-            port: "22"
-            credentialsId: "jenkins-jck-ssh"
-            javaPath: ""
-            sshHostKeyVerificationStrategy:
-              manuallyProvidedKeyVerificationStrategy:
-                key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDCSTNTGL3mf3dBPWjkBF2JgQceXIyuTmyXhxvFPzSXn8wFmG9Nz09L0jLyfL5NtbN4nZe65fc7/bhfo4bnr9PmDTcIldW7Y59ScTC3ink9YNYiRJpYsuJ14T0scLHPfb6rRv6MpRGsulGL0dnbbPAJE8RQ9om1JEid/unE/IpbCgfuodQQ0wjVxwc5UpcmJ8G2/spuW8QApZzVUqaUyiBSDtOnczBXcdOIX1t74RN9jf1sxVzjjEfjatQkgK7hnHFczAJPBGOQgApVYWKi/bKKtlT0w3XwdaFw9l5a5+JyKogpmR2EjG9Je3Vy2S4ZhvpMGat0mudOeoE9zvIhSCNPkX0NYyF8BdCqAaky33tXZH+XnM3XAaqGZLADn+RmLvKx2ZyFU9VFGkd0gscljCi8etvBGE7+ZbSZLa8LCydvDedzLM+2HhRraR758cV0r51Rv7DqRfH2DAjZA76KKeHRA9NrRbMKisbYvzxC8GnJb/BOxBp942usQqpa0HZBczM="
-    - permanent:
         name: "jck-marist-ubuntu2004-s390x-3"
         nodeDescription: "2-core 4Gb zLinux machine hosted at Marist"
         labelString: "ci.role.test hw.arch.s390x sw.os.linux"
@@ -412,23 +378,6 @@ jenkins:
             sshHostKeyVerificationStrategy:
               manuallyProvidedKeyVerificationStrategy:
                 key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPgLhlW7LdMg6VRkyl4trVUWvUvHD92264xtC7rgFe8s"
-    - permanent:
-        name: "jck-marist-rhel7-s390x-1"
-        nodeDescription: "2-core 4Gb zLinux machine hosted at Marist Cloud"
-        labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-        remoteFS: '/home/jenkins'
-        numExecutors: 1
-        mode: EXCLUSIVE
-        retentionStrategy: "always"
-        launcher:
-          ssh:
-            host: "148.100.84.144"
-            port: "22"
-            credentialsId: "jenkins-jck-ssh"
-            javaPath: ""
-            sshHostKeyVerificationStrategy:
-              manuallyProvidedKeyVerificationStrategy:
-                key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBCQ3k2UtFTNTPZDpbyjwuwodCW3iZ5v45naMsVnVbW665eYuanAAL9cCvCLQONUDwmacvKw5sAQlWH6xeNVxxSJTUPdAFrg00rLi23VKqX/rYKjqbcRrUEx/cXgQ25SEVRys+T4onH0mu0Eww2s5rMPWf9qbhEVKkaMIJDm4VPsRIs4bJQoDqd0wqEYlnksmNd1aecYoWtcF8/h5ce8w8iNITTfX+c8uTPSsveadOge11EZIc1uFoX1vfwcq5Ne4dchheH1RuBPFVoZETAuxCIgomcYaXn3TOr+5EIAfA6C8x5yEAuUJ+Yme59gLozBUHZV+SaEu4K5kSLf3dohyH"
     - permanent:
         name: "jck-marist-rhel7-s390x-2"
         nodeDescription: "2-core 4Gb machine hosted at Marist Cloud"

--- a/instances/adoptium.temurin-compliance/target/k8s/configmap-jenkins-config.yml
+++ b/instances/adoptium.temurin-compliance/target/k8s/configmap-jenkins-config.yml
@@ -367,40 +367,6 @@ data:
                   manuallyProvidedKeyVerificationStrategy:
                     key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC6AZ52BYtn9IHiTNleFhxPuzfVZ62i8OaRJVvCzheTU2mRePox9ipTv3V/okLuMRtD01gpXQpqax3CqaiSpc+bw/8Utcoe3zQaIEX61bvC6lA5eLN60662z3LH1Mf/QxYb2BNSRjvMtzK5+QnbHQJIX1091kOCu/0KLPrgd78ItYnZj3ZMUUWCycjQwsxcJPLNDL7oKBAkNwIjVfD5cPJMIkatTD7Li82E3rNfg/mfshTvdzHzkxryaIx9G9KwmdXtgWiWH4ZVpz3TvadZITyTy67PFbQrClVN+EOPw8jg0n4aMOckc6+Dk8bsDzwWIm2KuTP3BCU3U/VHSK3u7BKhY0tBw88x4jXmZuT+UASLSFFfyUMwHJYjiUuev8FYwVdxy1z5ZMnjaEq/ovemliRBRpOUdgKpegiLxsUZ8hJRwRX5rAD/74nJdMRdtDYYq74lrdcddakyyfxR0lq8/i9AV+kXTEgBCmZeGDXfgFFKb/3GXnnevST0szUnm/ZSkRk="
         - permanent:
-            name: "jck-marist-ubuntu2004-s390x-1"
-            nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-            labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-            remoteFS: '/home/jenkins'
-            numExecutors: 1
-            mode: EXCLUSIVE
-            retentionStrategy: "always"
-            launcher:
-              ssh:
-                host: "148.100.84.95"
-                port: "22"
-                credentialsId: "jenkins-jck-ssh"
-                javaPath: ""
-                sshHostKeyVerificationStrategy:
-                  manuallyProvidedKeyVerificationStrategy:
-                    key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK0XaYiD+TSQoEmNoJ4TJl8yWUnYSqdLezQTU7RvqiqZUr7y2Fj0kcV1oP8j0+PgBDhEv3pl3zBQeHPlFeomcAb7by0M9GAkrM24tA/Vjld5Nmceagqnabv9Q/lpz2Bi+ke0rOirMI5Ekv/Y5HDf8Sr9AfRvPpvwCwXR0kugssr3+gvetjKQBYJil2IBcsaAEW/yuHFV2W5r9TowjLvORvTYCN5bGNlDye1YBwzs5y0YslgdS8wObsaeExZH57mnQ79nEljPWVIP5gzfraunRX4iGEtOJxEL2O02j58LelbTxaHlL13o89n6M0N8dyqwNwKlOv/LPsmKC0oEA/aPEbHirzDyxNYcTuS4or4F5AyGrjr8mQYiWep93hiJand1Mymrb8XsHNV2qwQRZrNP1IHZ4IaKuI7PJYzyfEA/ksDgrGOoAbc5Aj6QWaG1ep//XvYKPzyWeR8SDV68f/Avobt5nmqEHyeYFfjcfDpDZQvdP2SUtRPa++iD2BQsMsc1M="
-        - permanent:
-            name: "jck-marist-ubuntu2004-s390x-2"
-            nodeDescription: "2-core 8Gb zLinux machine hosted at Marist"
-            labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-            remoteFS: '/home/jenkins'
-            numExecutors: 1
-            mode: EXCLUSIVE
-            retentionStrategy: "always"
-            launcher:
-              ssh:
-                host: "148.100.84.175"
-                port: "22"
-                credentialsId: "jenkins-jck-ssh"
-                javaPath: ""
-                sshHostKeyVerificationStrategy:
-                  manuallyProvidedKeyVerificationStrategy:
-                    key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDCSTNTGL3mf3dBPWjkBF2JgQceXIyuTmyXhxvFPzSXn8wFmG9Nz09L0jLyfL5NtbN4nZe65fc7/bhfo4bnr9PmDTcIldW7Y59ScTC3ink9YNYiRJpYsuJ14T0scLHPfb6rRv6MpRGsulGL0dnbbPAJE8RQ9om1JEid/unE/IpbCgfuodQQ0wjVxwc5UpcmJ8G2/spuW8QApZzVUqaUyiBSDtOnczBXcdOIX1t74RN9jf1sxVzjjEfjatQkgK7hnHFczAJPBGOQgApVYWKi/bKKtlT0w3XwdaFw9l5a5+JyKogpmR2EjG9Je3Vy2S4ZhvpMGat0mudOeoE9zvIhSCNPkX0NYyF8BdCqAaky33tXZH+XnM3XAaqGZLADn+RmLvKx2ZyFU9VFGkd0gscljCi8etvBGE7+ZbSZLa8LCydvDedzLM+2HhRraR758cV0r51Rv7DqRfH2DAjZA76KKeHRA9NrRbMKisbYvzxC8GnJb/BOxBp942usQqpa0HZBczM="
-        - permanent:
             name: "jck-marist-ubuntu2004-s390x-3"
             nodeDescription: "2-core 4Gb zLinux machine hosted at Marist"
             labelString: "ci.role.test hw.arch.s390x sw.os.linux"
@@ -435,23 +401,6 @@ data:
                 sshHostKeyVerificationStrategy:
                   manuallyProvidedKeyVerificationStrategy:
                     key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPgLhlW7LdMg6VRkyl4trVUWvUvHD92264xtC7rgFe8s"
-        - permanent:
-            name: "jck-marist-rhel7-s390x-1"
-            nodeDescription: "2-core 4Gb zLinux machine hosted at Marist Cloud"
-            labelString: "ci.role.test hw.arch.s390x sw.os.linux"
-            remoteFS: '/home/jenkins'
-            numExecutors: 1
-            mode: EXCLUSIVE
-            retentionStrategy: "always"
-            launcher:
-              ssh:
-                host: "148.100.84.144"
-                port: "22"
-                credentialsId: "jenkins-jck-ssh"
-                javaPath: ""
-                sshHostKeyVerificationStrategy:
-                  manuallyProvidedKeyVerificationStrategy:
-                    key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBCQ3k2UtFTNTPZDpbyjwuwodCW3iZ5v45naMsVnVbW665eYuanAAL9cCvCLQONUDwmacvKw5sAQlWH6xeNVxxSJTUPdAFrg00rLi23VKqX/rYKjqbcRrUEx/cXgQ25SEVRys+T4onH0mu0Eww2s5rMPWf9qbhEVKkaMIJDm4VPsRIs4bJQoDqd0wqEYlnksmNd1aecYoWtcF8/h5ce8w8iNITTfX+c8uTPSsveadOge11EZIc1uFoX1vfwcq5Ne4dchheH1RuBPFVoZETAuxCIgomcYaXn3TOr+5EIAfA6C8x5yEAuUJ+Yme59gLozBUHZV+SaEu4K5kSLf3dohyH"
         - permanent:
             name: "jck-marist-rhel7-s390x-2"
             nodeDescription: "2-core 4Gb machine hosted at Marist Cloud"


### PR DESCRIPTION
Removes jck-marist-rhel7-s390x-1, jck-marist-ubuntu2004-s390x-1, jck-marist-ubuntu2004-s390x-2 nodes. EF issue #2214 https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2214

Signed-off-by: Paweł Stankiewicz <pawel.stankiewicz@eclipse-foundation.com>