### PR TITLE
jck-equinix-containerized-ubuntu2004-aarch32-1 updgrading to JDK-11

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -488,6 +488,8 @@ jenkins:
       retentionStrategy: "always"
       launcher:
         ssh:
+          javaPath: "/usr/lib/jvm/jdk-11/bin/java"
+          jvmOptions: "-Xmx512m"
           credentialsId: "jenkins-jck-ssh"
           host: "139.178.86.125"
           port: 2222

--- a/instances/adoptium.temurin-compliance/target/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/target/jenkins/configuration.yml
@@ -807,6 +807,8 @@ jenkins:
             credentialsId: "jenkins-jck-ssh"
             host: "139.178.86.125"
             port: 2222
+            javaPath: "/usr/lib/jvm/jdk-11/bin/java"
+            jvmOptions: "-Xmx512m"
             sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
     - permanent:
         name: "jck-digitalocean-containerized-alpine313-x64-1"

--- a/instances/adoptium.temurin-compliance/target/k8s/configmap-jenkins-config.yml
+++ b/instances/adoptium.temurin-compliance/target/k8s/configmap-jenkins-config.yml
@@ -828,6 +828,8 @@ data:
             launcher:
               ssh:
                 credentialsId: "jenkins-jck-ssh"
+                javaPath: "/usr/lib/jvm/jdk-11/bin/java"
+                jvmOptions: "-Xmx512m"
                 host: "139.178.86.125"
                 port: 2222
                 sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"


### PR DESCRIPTION
Agent jck-equinix-containerized-ubuntu2004-aarch32-1 updgrading to JDK-11

Issue https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2354

Signed-off-by: Pawel Stankiewicz <pawel.stankiewicz@eclipse-foundation.org>