### PR TITLE
[temurin-compliance] Remove ci.role.test and add worker label to mythicbeasts-mvyo8-debian10-aarch32

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -456,7 +456,7 @@ jenkins:
   - permanent:
       name: "mythicbeasts-mvyo8-debian10-aarch32"
       nodeDescription: "RaspberryPi 4 with Debian 10 hosted at Mythic Beast"
-      labelString: "ci.role.test hw.arch.aarch32 sw.os.linux"
+      labelString: "hw.arch.aarch32 sw.os.linux worker"
       remoteFS: '/home/jenkins'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
temurin-compliance test pipeline architecture requires a "worker" labelled node to best optimize end of test artifact archiving, without it large backlogs can build during release testing.
mythicbeasts-mvyo8-debian10-aarch32 is currently disconnected due to insufficient inodes, but would be ideal as the "worker" node.
This PR removes "ci.role.test" (so that no tests try to run on it), and adds "worker".

Signed-off-by: Andrew Leonard <anleonar@redhat.com>