### PR TITLE
Create 'swt.natives' labels for eclipse.platform.releng Jenkins agents

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -3,7 +3,7 @@ jenkins:
   - permanent:
       name: "b9h15-macos10.15"
       nodeDescription: "macOS 10.15 (Catalina), no login session, hosted on MacStadium"
-      labelString: "macos macos-10.15"
+      labelString: "macos macos-10.15 swt.natives-cocoa.macosx.aarch64 swt.natives-cocoa.macosx.x86_64"
       remoteFS: '/Users/genie.releng/jenkins_agent/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -27,7 +27,7 @@ jenkins:
   - permanent:
       name: "rs68g-win10"
       nodeDescription: "Windows 10 Pro, hosted on Azure"
-      labelString: "windows"
+      labelString: "windows swt.natives-win32.win32.x86_64"
       remoteFS: 'C:\Users\genie.releng\ci'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -93,7 +93,7 @@ jenkins:
           onlineAddresses: "releng@eclipse.org"
   - permanent:
       name: "ppcle-buildTest"
-      labelString: "ppctest ppcbuild"
+      labelString: "ppctest ppcbuild swt.natives-gtk.linux.ppc64le"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
       mode: EXCLUSIVE
@@ -121,7 +121,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-1"
-      labelString: "aarch64 arm64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -136,7 +136,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-2"
-      labelString: "aarch64 arm64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -151,7 +151,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-3"
-      labelString: "aarch64 arm64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -166,7 +166,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-4"
-      labelString: "aarch64 arm64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1


### PR DESCRIPTION
As part of https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2448 systematically named labels are added to those agents that are capable to build the SWT native binaries for a certain platform. The label name indicates for which platform the natives can be build by the agent and therefore allow their use in a Jenkins matrix stage.

I added the labels based on the current configuration of the jobs in https://ci.eclipse.org/releng/view/SWT%20Natives/.

@fredg02 can you please review and merge this.