### PR TITLE
Add k8-cloud to platform.releng Jenkins

### DIFF
--- a/instances/eclipse.platform.releng/config.jsonnet
+++ b/instances/eclipse.platform.releng/config.jsonnet
@@ -19,6 +19,35 @@ local permissionsTemplates = import '../../templates/permissions.libsonnet';
       // https://bugs.eclipse.org/bugs/show_bug.cgi?id=562806#c15
       permissionsTemplates.projectPermissions("akurtakov@gmail.com", ["Agent/Connect", "Agent/Disconnect"])
   },
+  clouds+: {
+    kubernetes+: {
+      local currentCloud = self,
+      templates+: {
+        "jipp-centos-7-agent-6gb": currentCloud.templates["centos-7"] {
+          labels: ["centos-7-6gb"],
+          kubernetes+: {
+            resources+: {
+              memory: {
+                limit: "6144Mi",
+                request: "6144Mi",
+              },
+            },
+          },
+        },
+        "jipp-centos-8-agent-4cpu": currentCloud.templates["centos-8"] {
+          labels: ["centos-8-4cpu"],
+          kubernetes+: {
+            resources+: {
+              cpu: {
+                limit: "4000m",
+                request: "4000m",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   maven+: {
     local superSettings = super.files["settings.xml"],
     files+: {


### PR DESCRIPTION
At the moment the eclipse.platform.swt job on the eclipse.platform.releng Jenkins cannot be launched, even after adjusting the kubernetes-agent specification in the Jenkinsfile:
 https://ci.eclipse.org/releng/job/eclipse.platform.swt/job/PR-533/1/console
```
Pull request #533 opened
02:54:58 Connecting to https://api.github.com/ using GitHub bot (username/token)
Connecting to https://api.github.com/ to check permissions of obtain list of HannesWell for eclipse-platform/eclipse.platform.swt
Obtained Jenkinsfile from c02759d53bf142b2705f3a93f27a0e36d77860e4
[Pipeline] Start of Pipeline
[Pipeline] echo
[WARNING] label option is deprecated. To use a static pod template, use the 'inheritFrom' option.
[Pipeline] podTemplate
[Pipeline] {
[Pipeline] node
Still waiting to schedule task
‘[swtbuild-pod-8z9j2-53cgc](https://ci.eclipse.org/releng/computer/swtbuild%2Dpod%2D8z9j2%2D53cgc/)’ is offline
```
Because I cannot continue with https://github.com/eclipse-platform/eclipse.platform.swt/pull/514#issuecomment-1374639363, due to pending eclipse.platform.releng Jenkins changes we should make the current Pipeline work.

From comparing
- https://github.com/eclipse-cbi/jiro/blob/master/instances/eclipse.platform/config.jsonnet
- https://github.com/eclipse-cbi/jiro/blob/master/instances/eclipse.platform.releng/config.jsonnet

I got the impression that this change is the missing part to make https://github.com/eclipse-platform/eclipse.platform.swt/pull/533 work and eventually solve https://github.com/eclipse-platform/eclipse.platform.swt/issues/531.

But this is only from comparing the content of the parent folders without any deeper knowledge. I have no clue if this is really the solution.
@fredg02 can you please review this carefully?

~~Since it looks like platform.swt only uses centos-8 I skipped the centos-7 template.~~
