### PR TITLE
Add K8-Agent to 'e.platform.releng' to build linux.x86_64 swt-natives

### DIFF
--- a/instances/eclipse.platform.releng/config.jsonnet
+++ b/instances/eclipse.platform.releng/config.jsonnet
@@ -19,6 +19,39 @@ local permissionsTemplates = import '../../templates/permissions.libsonnet';
       // https://bugs.eclipse.org/bugs/show_bug.cgi?id=562806#c15
       permissionsTemplates.projectPermissions("akurtakov@gmail.com", ["Agent/Connect", "Agent/Disconnect"])
   },
+  clouds+: {
+    kubernetes+: {
+      local currentCloud = self,
+      templates+: {
+        "jipp-swt-natives-linux.x84_64": currentCloud.templates["centos-8"] {
+          labels: ["swt.natives-gtk.linux.x86_64"],
+          docker+: {
+            repository: "eclipse"
+            image: "platformreleng-centos-swt-build"
+            tag: "8"
+          }
+          kubernetes+: {
+            resources+: {
+              cpu: {
+                limit: "2000m",
+                request: "1000m",
+              },
+              memory: {
+                limit: "4096Mi",
+                request: "512Mi",
+              },
+            },
+            volumes+: {
+              name: "tools"
+              mounts+: {
+                mountPath: "/opt/tools"
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   maven+: {
     local superSettings = super.files["settings.xml"],
     files+: {


### PR DESCRIPTION
This is an attempt to add a Kubernetes-Agent to the `eclipse.platform.releng` Jenkins based on the configuration defined in https://ci.eclipse.org/releng/view/SWT%20Natives/job/gtk_linux_x86_64/configure to be capable to build the swt-natives for linux.x86_64, while being addressable as agent with label `swt.natives-gtk.linux.x86_64`.

This is required for https://github.com/eclipse-platform/eclipse.platform.swt/pull/514 and was requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2448#note_1059781.

I'm not familiar with the JIRO and only created this by comparing/considering the following files:
- https://github.com/eclipse-cbi/jiro/blob/master/instances/eclipse.platform/config.jsonnet
- https://github.com/eclipse-cbi/jiro/blob/master/instances/eclipse.platform.releng/config.jsonnet
- https://github.com/eclipse-cbi/jiro/blob/master/templates/jenkins/configuration.yml.hbs

Therefore I'm not sure at, if this is the right thing to do or if something else is missing, but I hope it is and have a least a minimal level of confidence that it is not completely wrong.

The goal was to create an additional clouds-template like the following in https://github.com/eclipse-cbi/jiro/blob/master/instances/eclipse.platform.releng/target/jenkins/configuration.yml, what is hopefully what is needed to achieve the described result.

<details>
  <summary>Expected additional Cloud template</summary>
<code>
clouds:
    - kubernetes:
        name: "kubernetes"
        containerCapStr: "10"
        jenkinsUrl: "http://jenkins-ui.releng.svc.cluster.local/releng"
        jenkinsTunnel: "jenkins-discovery.releng.svc.cluster.local:50000"
        maxRequestsPerHostStr: "32"
        namespace: "releng"
        podRetention: "never"
        templates:
          - name: "swtbuild"
            namespace: "releng"
            label: "swt.natives-gtk.linux.x86_64"
            containers:
              - name: "jnlp"
                image: docker.io/eclipse/platformreleng-centos-swt-build:8
                alwaysPullImage: true
                livenessProbe:
                  failureThreshold: 0
                  initialDelaySeconds: 0
                  periodSeconds: 0
                  successThreshold: 0
                  timeoutSeconds: 0
                resourceLimitCpu: "2000m"
                resourceRequestCpu: "1000m"
                resourceLimitMemory: "4096Mi"
                resourceRequestMemory: "512Mi"
                ttyEnabled: true
                command: ""
                args: ""
            instanceCap: -1
            nodeUsageMode: EXCLUSIVE
            envVars:
              - envVar:
                  key: "JAVA_TOOL_OPTIONS"
                  value: ""
              - envVar:
                  key: "JENKINS_REMOTING_JAVA_OPTS"
                  value: "-showversion -XshowSettings:vm -Xmx256m -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true -Dorg.jenkinsci.plugins.gitclient.CliGitAPIImpl.useSETSID=true"
              - envVar:
                  key: "OPENJ9_JAVA_OPTIONS"
                  value: "-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
              - envVar:
                  key: "_JAVA_OPTIONS"
                  value: ""
            volumes:
              - persistentVolumeClaim:
                  claimName: "tools-claim-jiro-releng"
                  mountPath: "/opt/tools"
                  readOnly: true
              - configMapVolume:
                  configMapName: "known-hosts"
                  mountPath: "/home/jenkins/.ssh/"
                  subPath: "."
              - emptyDirVolume:
                  memory: false
                  mountPath: "/home/jenkins/"
              - emptyDirVolume:
                  memory: false
                  mountPath: "/home/jenkins/.m2/repository"
              - emptyDirVolume:
                  memory: false
                  mountPath: "/home/jenkins/.m2/wrapper"
            workspaceVolume:
              emptyDirWorkspaceVolume:
                memory: false
            yaml: |
              apiVersion: v1
              kind: Pod
              spec:
                containers:
                - name: "swtbuild"
                  image: "eclipse/platformreleng-centos-swt-build:8"
                  imagePullPolicy: "Always"
                  resources:
                    limits:
                      memory: "4096Mi"
                      cpu: "2000m"
                    requests:
                      memory: "512Mi"
                      cpu: "1000m"
                  command:
                  - cat
                  tty: true
                  volumeMounts:
                  - name: tools
                    mountPath: /opt/tools
                volumes:
                - name: tools
                  persistentVolumeClaim:
                    claimName: tools-claim-jiro-releng
</code>
</details>

@fredg02 can you please review this in depth?
@sravanlakkimsetti, @akurtakov can you assess if the additional template is sufficient to build swt-natives for linux.x86_64?