### PR TITLE
Move 'swt.natives'-label for mac.aarch64 from b9h15-macos to nc1ht-macos

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -3,7 +3,7 @@ jenkins:
   - permanent:
       name: "b9h15-macos10.15"
       nodeDescription: "macOS 10.15 (Catalina), no login session, hosted on MacStadium"
-      labelString: "macos macos-10.15 swt.natives-cocoa.macosx.aarch64 swt.natives-cocoa.macosx.x86_64"
+      labelString: "macos macos-10.15 swt.natives-cocoa.macosx.x86_64"
       remoteFS: '/Users/genie.releng/jenkins_agent/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -181,7 +181,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "nc1ht-macos11-arm64"
-      labelString: "macos macos11"
+      labelString: "macos macos11 swt.natives-cocoa.macosx.aarch64"
       nodeDescription: "macOS Ventura 13.0.1"
       launcher:
         ssh:


### PR DESCRIPTION
In the releng JIPP, the SWT-natives for macosx.aarch64 can currently not be build on the 'b9h15-macos10.15' machine but only on the 'nc1ht-macos11-arm64'.

Part of https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2448 and required for https://github.com/eclipse-platform/eclipse.platform.swt/pull/514

As told in https://github.com/eclipse-platform/eclipse.platform.swt/pull/514#issuecomment-1408672288 both mac-machines should be fine (although only the setup created with this PR works).
As suggested in https://github.com/eclipse-platform/eclipse.platform.swt/pull/514#issuecomment-1409263936 this moves the labels accordingly.

@fredg02 can you please review and deploy this?

FXI @sravanlakkimsetti