### PR TITLE
Local config fails silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Dockerfile.buildlog
 /.cache
 /.localconfig
 /.cli_temp_dir/
+jcasc_update.log

--- a/utils/local_config.sh
+++ b/utils/local_config.sh
@@ -31,7 +31,7 @@ _check_if_var_exists() {
   local var="${1:-}"
   local name="${2:-}"
   if [[ -z "${var}" ]] || [[ "${var}" == "null" ]]; then
-    printf "ERROR: '${name}' must be set in %s.\n" "${LOCAL_CONFIG}"
+    printf "ERROR: '${name}' must be set in %s.\n" "${LOCAL_CONFIG}" >> /dev/tty
     exit 1
   fi
 }
@@ -56,10 +56,9 @@ get_var() {
   local lcv
 
   if [[ -z "${name}" ]]; then
-    printf "ERROR: 'name' must be set\n"
+    printf "ERROR: 'name' must be set\n" >> /dev/tty
     exit 1
   fi
-  
   if [[ -z "${group}" ]] || [[ "${group}" == "" ]]; then
     lcv="$(jq -r ".\"${name}\"" "${LOCAL_CONFIG}")"
     _check_if_var_exists "${lcv}" "${name}"


### PR DESCRIPTION
If there is missing entries in cbi configuration files, sub script like `local_config.sh` will not report or print errors. 
So the script exit and fail silently.

Ex: missing configuration in my case
"jenkins_login": {
     "user": "sebastien.heurtematte@eclipse-foundation.org",
     "pw": "XXXXXXXXXXXXXX"
  }

Try to run: /jenkins-cli.sh instances/foundation-internal.webdev reload-jcasc-configuration.

