### PR TITLE
Add the ansicolor plugin to the JGit Jenkins instance

### DIFF
--- a/instances/technology.jgit/config.jsonnet
+++ b/instances/technology.jgit/config.jsonnet
@@ -8,6 +8,7 @@
     theme: "quicksilver-light",
     staticAgentCount: 1,
     plugins+: [
+      "ansicolor",
       "dashboard-view",
       "git-forensics",
       "gradle",


### PR DESCRIPTION
The ansicolor plugin adds support for standard ANSI escape sequences, including color, to Console Output. This can improve readability of maven logs when configuring jobs to set `-Dstyle.color=always`.

See https://plugins.jenkins.io/ansicolor/