### PR TITLE
yq unknown input format json

### DIFF
--- a/build/gen-permissions.sh
+++ b/build/gen-permissions.sh
@@ -24,4 +24,4 @@ if [[ ! -f "${json}" ]]; then
 fi
 
 # removes duplicate entries, but does not merge entries
-jq -c '.jenkins.permissions | unique' "${json}" | yq -P 'sort_keys(..)' -p json -o yaml -
+jq -c '.jenkins.permissions | unique' "${json}" | yq -P 'sort_keys(..)' -o yaml -


### PR DESCRIPTION
According to yq: json format in not part of input value

I get this error n a jiro build: 

```
Error: unknown format 'json' please use [yaml|xml|props]
[2023-12-11 11:40:24][FATAL ][build-image.sh:34 ] Unexpected error (exit code: 1)
```

My local yq version: 4.25.1

Latest yq version: 4.40.4
https://github.com/mikefarah/yq/tree/v4.40.4

```
  -p, --input-format string           [yaml|y|xml|x] parse format for input. Note that json is a subset of yaml. (default "yaml")
```