### PR TITLE
Add view-job-filters plugin to temurin-compliance instance

### DIFF
--- a/instances/adoptium.temurin-compliance/target/jenkins/plugins-list.txt
+++ b/instances/adoptium.temurin-compliance/target/jenkins/plugins-list.txt
@@ -16,5 +16,6 @@ parameter-separator
 pipeline-utility-steps
 slack
 tap
+view-job-filters
 xunit
 xvfb


### PR DESCRIPTION
Add view-job-filters plugin to be able to create a Jenkins view of failing test jobs only.