### PR TITLE
Add generalized native-builder node labels

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -3,7 +3,7 @@ jenkins:
   - permanent:
       name: "b9h15-macos11-x86_64"
       nodeDescription: "macOS 11 (Big Sur), no login session, hosted on MacStadium"
-      labelString: "macos macos-11 swt.natives-cocoa.macosx.x86_64"
+      labelString: "macos macos-11 swt.natives-cocoa.macosx.x86_64 native.builder-cocoa.macosx.x86_64"
       remoteFS: '/Users/genie.releng/jenkins_agent/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -27,7 +27,7 @@ jenkins:
   - permanent:
       name: "rs68g-win10"
       nodeDescription: "Windows 10 Pro, hosted on Azure"
-      labelString: "windows swt.natives-win32.win32.x86_64"
+      labelString: "windows swt.natives-win32.win32.x86_64 native.builder-win32.win32.x86_64"
       remoteFS: 'C:\Users\genie.releng\ci'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -93,7 +93,7 @@ jenkins:
           onlineAddresses: "releng@eclipse.org"
   - permanent:
       name: "ppcle-buildTest"
-      labelString: "ppctest ppcbuild swt.natives-gtk.linux.ppc64le"
+      labelString: "ppctest ppcbuild swt.natives-gtk.linux.ppc64le native.builder-gtk.linux.ppc64le"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
       mode: EXCLUSIVE
@@ -121,7 +121,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-1"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -136,7 +136,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-2"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -151,7 +151,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-3"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -166,7 +166,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-4"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build"
       numExecutors: 1
@@ -181,7 +181,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "nc1ht-macos11-arm64"
-      labelString: "macos macos11 swt.natives-cocoa.macosx.aarch64"
+      labelString: "macos macos11 swt.natives-cocoa.macosx.aarch64 native.builder-cocoa.macosx.aarch64"
       nodeDescription: "macOS Ventura 13.0.1"
       launcher:
         ssh:
@@ -224,7 +224,7 @@ jenkins:
       remoteFS: "C:\\Users\\genie.releng\\"
       retentionStrategy: "always"
   - permanent:
-      labelString: "windows windows11 swt.natives-win32.win32.aarch64"
+      labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64"
       launcher:
         inbound:
           webSocket: true


### PR DESCRIPTION
Now that not only SWT but also Equinox uses the specialized build agents to build native binaries (see https://github.com/eclipse-equinox/equinox/pull/603) it would be good to generalize the labels that indicate which node can be used to build for which platform.