### PR TITLE
Override cpu/memory request and limit from jenkinsfile

### DIFF
--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -62,10 +62,6 @@ jenkins:
             periodSeconds: 0
             successThreshold: 0
             timeoutSeconds: 0
-          resourceLimitCpu: "{{this.kubernetes.resources.cpu.limit}}"
-          resourceRequestCpu: "{{this.kubernetes.resources.cpu.request}}"
-          resourceLimitMemory: "{{this.kubernetes.resources.memory.limit}}"
-          resourceRequestMemory: "{{this.kubernetes.resources.memory.request}}"
           ttyEnabled: true
           command: ""
           args: ""
@@ -128,6 +124,13 @@ jenkins:
           spec:
             containers:
             - name: jnlp
+              resources:
+                limits:
+                  cpu: "{{this.kubernetes.resources.cpu.limit}}"
+                  memory: "{{this.kubernetes.resources.memory.limit}}"
+                requests:
+                  cpu: "{{this.kubernetes.resources.cpu.request}}"
+                  memory: "{{this.kubernetes.resources.memory.request}}"
               volumeMounts:
               {{#each kubernetes.volumes}}
               {{#each mounts}}


### PR DESCRIPTION
This allow to merge yaml definition from a JenkinsFile

E.g: 

```yaml
pipeline {
    agent {
        kubernetes {
          inheritFrom 'centos-8'
          yaml """
    spec:
      containers:
      - name: jnlp
        resources:
          limits:
            memory: "3Gi"
            cpu: "2000m"
          requests:
            memory: "3Gi"
            cpu: "2000m"
    """
        }
    }

    stages {
        stage('Main') {
            steps {
                sh 'hostname'
            }
        }
    }
}
```

According to this issue: https://issues.jenkins.io/browse/JENKINS-70061, webui configuration always overrides yaml configuration.  
