### PR TITLE
Change yaml merge strategy to `merge` for pod template

### DIFF
--- a/templates/clouds.libsonnet
+++ b/templates/clouds.libsonnet
@@ -8,6 +8,8 @@
         [agentName]: agents[agentName].spec + agents[agentName].variants[config.jiroMaster.remoting.version] + {
           kubernetes: {
             resources: config.kubernetes.agents.defaultResources,
+            inheritYamlMergeStrategy: true,
+            yamlMergeStrategy: "merge",
             local dot_m2 = agents[agentName].spec.home + "/.m2",
             volumes: (if config.maven.generate then [
               {

--- a/templates/jenkins/configuration.yml.hbs
+++ b/templates/jenkins/configuration.yml.hbs
@@ -146,6 +146,8 @@ jenkins:
               {{#if configMap}}configMap{{/if}}{{#if secret}}secret{{/if}}:
                 {{#if configMap}}name: {{configMap.name}}{{/if}}{{#if secret}}secretName: {{secret.name}}{{/if}}
             {{/each}}
+        inheritYamlMergeStrategy: "{{this.kubernetes.inheritYamlMergeStrategy}}"
+        yamlMergeStrategy: "{{this.kubernetes.yamlMergeStrategy}}"
       {{/each}}
   {{/each}}
 security:


### PR DESCRIPTION
The default merge strategy for yaml definition in podtemplate is `override`. 
Define specific values in podtemplate with inherit keyword lose all predefined mount volumes. 

Change the yaml merge strategy to `merge`.


See comment here: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2149#issuecomment-2190033142