### PR TITLE
Link native build nodes into eclipse.platform and equinox JIPP

### DIFF
--- a/instances/eclipse.equinox/config.jsonnet
+++ b/instances/eclipse.equinox/config.jsonnet
@@ -2,6 +2,8 @@
   project+: {
     fullName: "eclipse.equinox",
     displayName: "Eclipse Equinox"
+    # remoteFSSuffix must be individual among all JIPPs which link the eclipse.platform.releng/jenkins/configuration.yml
+    remoteFSSuffix: "equinox",
   },
   jenkins+: {
     plugins+: [

--- a/instances/eclipse.equinox/jenkins/configuration.yml
+++ b/instances/eclipse.equinox/jenkins/configuration.yml
@@ -1,0 +1,1 @@
+../../eclipse.platform.releng/jenkins/configuration.yml

--- a/instances/eclipse.platform.releng/config.jsonnet
+++ b/instances/eclipse.platform.releng/config.jsonnet
@@ -6,6 +6,8 @@ local permissionsTemplates = import '../../templates/permissions.libsonnet';
     displayName: "Eclipse Platform Releng",
     resourcePacks: 5,
     unixGroupName: "eclipse.platform",
+    # remoteFSSuffix must be individual among all JIPPs which link the eclipse.platform.releng/jenkins/configuration.yml
+    remoteFSSuffix: "releng",
   },
   jenkins+: {
     plugins+: [

--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -4,7 +4,7 @@ jenkins:
       name: "b9h15-macos11-x86_64"
       nodeDescription: "macOS 11 (Big Sur), no login session, hosted on MacStadium"
       labelString: "macos macos-11 swt.natives-cocoa.macosx.x86_64 native.builder-cocoa.macosx.x86_64"
-      remoteFS: '/Users/genie.releng/jenkins_agent/'
+      remoteFS: '/Users/genie.releng/jenkins_agent/{{ project.remoteFSSuffix }}/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -28,7 +28,7 @@ jenkins:
       name: "rs68g-win10"
       nodeDescription: "Windows 10 Pro, hosted on Azure"
       labelString: "windows swt.natives-win32.win32.x86_64 native.builder-win32.win32.x86_64"
-      remoteFS: 'C:\Users\genie.releng\ci'
+      remoteFS: 'C:\Users\genie.releng\ci\{{ project.remoteFSSuffix }}\'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -66,7 +66,7 @@ jenkins:
       name: "zyt5z-centos83"
       nodeDescription: "Dedicated agent for performance tests, hosted on Azure"
       labelString: "performance docker-build"
-      remoteFS: '/home/genie.releng/jenkins'
+      remoteFS: '/home/genie.releng/jenkins/{{ project.remoteFSSuffix }}/'
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -94,7 +94,7 @@ jenkins:
   - permanent:
       name: "ppcle-buildTest"
       labelString: "ppctest ppcbuild swt.natives-gtk.linux.ppc64le native.builder-gtk.linux.ppc64le"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -108,7 +108,7 @@ jenkins:
   - permanent:
       name: "ppcle-test"
       labelString: "ppctest"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -123,7 +123,7 @@ jenkins:
       name: "centos-aarch64-1"
       labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -138,7 +138,7 @@ jenkins:
       name: "centos-aarch64-2"
       labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -153,7 +153,7 @@ jenkins:
       name: "centos-aarch64-3"
       labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -168,7 +168,7 @@ jenkins:
       name: "centos-aarch64-4"
       labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
-      remoteFS: "/home/swtbuild/build"
+      remoteFS: "/home/swtbuild/build/{{ project.remoteFSSuffix }}/"
       numExecutors: 1
       mode: EXCLUSIVE
       retentionStrategy: "always"
@@ -199,7 +199,7 @@ jenkins:
             key: "hudson.model.JDK$DescriptorImpl@openjdk-jdk17-latest"
           - home: "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home/bin"
             key: "hudson.model.JDK$DescriptorImpl@adoptopenjdk-hotspot-jdk11-latest"
-      remoteFS: "/Users/genie.releng"
+      remoteFS: "/Users/genie.releng/{{ project.remoteFSSuffix }}/"
       retentionStrategy: "always"
   - permanent:
       name: "qa6xd-win11"
@@ -221,7 +221,7 @@ jenkins:
           locations:
           - home: "C:\\ProgramData\\chocolatey\\lib\\ant\\tools\\apache-ant-1.10.13"
             key: "hudson.tasks.Ant$AntInstallation$DescriptorImpl@apache-ant-latest"
-      remoteFS: "C:\\Users\\genie.releng\\"
+      remoteFS: "C:\\Users\\genie.releng\\{{ project.remoteFSSuffix }}\\"
       retentionStrategy: "always"
   - permanent:
       labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64"
@@ -235,7 +235,7 @@ jenkins:
       mode: EXCLUSIVE
       name: "rie8t-win11-arm64"
       nodeDescription: "Windows 11 Pro ARM64, 2vCPUs, 8GB RAM, hosted on Azure"
-      remoteFS: "C:\\Users\\genie.releng.rie8t-win11-arm\\jenkins_agent"
+      remoteFS: "C:\\Users\\genie.releng.rie8t-win11-arm\\jenkins_agent\\{{ project.remoteFSSuffix }}\\"
       retentionStrategy: "always"
       nodeProperties:
       - watcher:

--- a/instances/eclipse.platform/config.jsonnet
+++ b/instances/eclipse.platform/config.jsonnet
@@ -3,6 +3,8 @@
     fullName: "eclipse.platform",
     displayName: "Eclipse Platform",
     resourcePacks: 4,
+    # remoteFSSuffix must be individual among all JIPPs which link the eclipse.platform.releng/jenkins/configuration.yml
+    remoteFSSuffix: "platform",
   },
   jenkins+: {
     plugins+: [

--- a/instances/eclipse.platform/jenkins/configuration.yml
+++ b/instances/eclipse.platform/jenkins/configuration.yml
@@ -1,0 +1,1 @@
+../../eclipse.platform.releng/jenkins/configuration.yml


### PR DESCRIPTION
Besides linking the 'jenkins/configuration.yml' to the eclipse.platform and equinox JIPP, this introduce the placeholder `&&INSTANCE_NAME&&` which is replaced with the project's full name while building images.
In this case this is used to ensure different workspace locations for the different JIPPs that use the native nodes.

Required for https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4231

Instead of introducing a new placeholder `&&INSTANCE_NAME&&`, maybe `{{this.project.fullName}}` could be used instead with the existing templating mechanism?
But I was unable to test that since I failed to setup a functioning CI pipeline that successfully run `make image_eclipse.platform`.
One problem was the installation of an alternative hbs-cli version that does not suffer from https://github.com/keithamus/hbs-cli/issues/68, like
- https://github.com/yasammez/hbs-cli/tree/ed85bd9e10f54b23331a36b51a6dd4e4134fb9c1
- https://github.com/heurtematte/hbs-cli (does it fix that?)

If you can confirm that `{{this.project.fullName}}` is a usable equivalent or can tell such usable equivalent for `&&INSTANCE_NAME&&`, I would be more than happy to use that instead of introducing a new variable.
