### PR TITLE
feat: add extra label for AIX 7.2TL05 system

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -274,7 +274,7 @@ jenkins:
   - permanent:
       name: "jck-skytap-aix72-ppc64-5"
       nodeDescription: "AIX 7.2 machine hosted by Skytap"
-      labelString: "ci.role.test hw.arch.ppc64 sw.os.aix sw.os.aix.7_2"
+      labelString: "ci.role.test hw.arch.ppc64 sw.os.aix sw.os.aix.7_2 sw.os.aix.7_2TL5"
       remoteFS: '/home/jenkins'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
Adding label so the correct machine can be selected that can run JDK22+