### PR TITLE
Add a JIRO link in the header with a link to the jiro github repo

### DIFF
--- a/build/gen-jenkins.sh
+++ b/build/gen-jenkins.sh
@@ -46,8 +46,23 @@ echo "/* GENERATED FILE - DO NOT EDIT */" > "${target}/${jenkinsTheme}.css.overr
 hbs -s -D "${instance}/target/config.json" "${jenkinsTemplateFolder}/${jenkinsTheme}.css.hbs" >> "${target}/${jenkinsTheme}.css.override"
 
 displayName="$(jq -r '.project.displayName' "${instance}/target/config.json")"
+fullName="$(jq -r '.project.fullName' "${instance}/target/config.json")"
 cat <<EOF > "${target}/title.js"
 document.title = "${displayName} - " + document.title;
+document.addEventListener('DOMContentLoaded', function() {
+    let header = document.querySelector('.page-header__brand');
+    if (header) {
+        let newLink = document.createElement('a');
+        newLink.href = 'https://github.com/eclipse-cbi/jiro/blob/master/instances/${fullName}/target/config.json';
+        newLink.textContent = 'JIRO';
+        newLink.style = 'color: white; border-left: 1px solid white; padding-left: 1em; font-size: 1.1em; position: relative; top: 0.2em; left: -1.6em;';
+        newLink.target = '_blank';
+        newLink.title = 'JIRO Configuration as Code';
+        header.appendChild(newLink);
+    } else {
+        console.log('Element with class "header" not found.');
+    }
+});
 EOF
 
 mkdir -p "${target}/partials"

--- a/build/gen-jenkins.sh
+++ b/build/gen-jenkins.sh
@@ -54,10 +54,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (header) {
         let newLink = document.createElement('a');
         newLink.href = 'https://github.com/eclipse-cbi/jiro/blob/master/instances/${fullName}/target/config.json';
-        newLink.textContent = 'JIRO';
+        newLink.textContent = 'JCasC Source';
         newLink.style = 'color: white; border-left: 1px solid white; padding-left: 1em; font-size: 1.1em; position: relative; top: 0.2em; left: -1.6em;';
         newLink.target = '_blank';
-        newLink.title = 'JIRO Configuration as Code';
+        newLink.title = 'JIRO JCasC Configuration as Code';
         header.appendChild(newLink);
     } else {
         console.log('Element with class "header" not found.');


### PR DESCRIPTION
Add a link in the header to the JIRO repository specifically the instance configuration as code. 

This aims to help projects understand their instance is configured as code, and even if they are not admin, they can access some configuration data. 

![image](https://github.com/user-attachments/assets/17b25f50-092c-4710-9e15-30a41adf524f)

With the existing instances, the file `/userContent/theme/title.js` has to be removed from the storage.

ref: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4784#note_2545026