### PR TITLE
Override default PVC values for jenkins home

### DIFF
--- a/templates/config.libsonnet
+++ b/templates/config.libsonnet
@@ -105,7 +105,18 @@ local clouds = import "clouds.libsonnet";
           timeoutSeconds: 10,
           failureThreshold: 5
         }
-      }
+      },
+      volumeClaimTemplates:{
+        jenkinsHomeSpec: {
+          storageClassName: "cephfs-2repl",
+          accessModes: ["ReadWriteOnce"],
+          resources: {
+            requests: {
+              storage: "50Gi",
+            },
+          },
+        },
+      },
     },
     agents: {
       namespace: $.kubernetes.master.namespace,  # should be changed to something agent-specific to fix #5

--- a/templates/k8s/statefulset.libsonnet
+++ b/templates/k8s/statefulset.libsonnet
@@ -246,14 +246,7 @@ local Kube = import "kube.libsonnet";
           metadata: {
             name: "jenkins-home",
           },
-          spec: {
-            accessModes: [ "ReadWriteOnce", ],
-            resources: {
-              requests: {
-                storage: "50Gi",
-              },
-            },
-          },
+          spec: config.kubernetes.master.volumeClaimTemplates.jenkinsHomeSpec
         },
       ],
     },


### PR DESCRIPTION
Values can be overrided in config.jsonnet: 

e.g: 

```jsonnet
  kubernetes+: {
    master+: {
      defaultJnlpAgentLabel: "basic-ubuntu",
      volumeClaimTemplates+: { 
        jenkinsHomeSpec+: {
          storageClassName: "cephfs",
          resources+: {
            requests+: {
              storage: "60Gi",
            },
          },
        },
      }
    }
  },
```
