### PR TITLE
Make storage quota customizable

### DIFF
--- a/templates/k8s/statefulset.libsonnet
+++ b/templates/k8s/statefulset.libsonnet
@@ -250,7 +250,10 @@ local Kube = import "kube.libsonnet";
             accessModes: [ "ReadWriteOnce", ],
             resources: {
               requests: {
-                storage: "50Gi",
+                storage: if std.objectHas(config, "storage") && std.objectHas(config.storage, "quota") then
+                  config.storage.quota
+                else
+                  "50Gi",  //default value
               },
             },
           },


### PR DESCRIPTION
Quota can be customized in `config.jsonnet `like this: 
```
{
  project+: {
    fullName: "foo.bar",
    displayName: "Eclipse Bar",
  },
  storage: {
    quota: "250Gi"
  }
```