### PR TITLE
fix: technology.omr add riscv64 agent.

### DIFF
--- a/instances/technology.omr/jenkins/configuration.yml
+++ b/instances/technology.omr/jenkins/configuration.yml
@@ -557,6 +557,7 @@ jenkins:
           - home: '/opt/freeware/bin/git'
             key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"            
 
+  - permanent:
       name: "riscv-build2"
       nodeDescription: "4-core 8Gb riscv machine hosted by EF"
       labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"

--- a/instances/technology.omr/target/jenkins/configuration.yml
+++ b/instances/technology.omr/target/jenkins/configuration.yml
@@ -1226,6 +1226,7 @@ jenkins:
               locations:
                 - home: '/opt/freeware/bin/git'
                   key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
+    - permanent:
         name: "riscv-build2"
         nodeDescription: "4-core 8Gb riscv machine hosted by EF"
         labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"

--- a/instances/technology.omr/target/jenkins/plugins.log
+++ b/instances/technology.omr/target/jenkins/plugins.log
@@ -126,13 +126,13 @@ warnings-ng 11.11.0
 workflow-aggregator 600.vb_57cdd26fdd7
 workflow-api 1336.vee415d95c521
 workflow-basic-steps 1058.vcb_fc1e3a_21a_9
-workflow-cps 3993.v3e20a_37282f8
+workflow-cps 3996.va_f5c1799f978
 workflow-durable-task-step 1378.v6a_3e903058a_3
 workflow-job 1436.vfa_244484591f
 workflow-multibranch 795.ve0cb_1f45ca_9a_
 workflow-scm-step 427.v4ca_6512e7df1
 workflow-step-api 678.v3ee58b_469476
-workflow-support 932.vb_555de1b_a_b_94
+workflow-support 936.v9fa_77211ca_e1
 ws-cleanup 0.47
 xvnc 1.28
 

--- a/instances/technology.omr/target/k8s/configmap-jenkins-config.yml
+++ b/instances/technology.omr/target/k8s/configmap-jenkins-config.yml
@@ -1249,6 +1249,7 @@ data:
                   locations:
                     - home: '/opt/freeware/bin/git'
                       key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
+        - permanent:
             name: "riscv-build2"
             nodeDescription: "4-core 8Gb riscv machine hosted by EF"
             labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"


### PR DESCRIPTION
Ref: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5254#note_2926949

Already deployed.