### PR TITLE
Add copyartifact plugin

### DIFF
--- a/instances/ecd.theia/config.jsonnet
+++ b/instances/ecd.theia/config.jsonnet
@@ -5,6 +5,7 @@
   },
   jenkins+: {
     plugins+: [
+      "copyartifact",
       "embeddable-build-status",
       "mail-watcher-plugin",
       "nodejs",


### PR DESCRIPTION
In order to make the build more stable we want to split the build into different parts, securing the in between states using artifacts.

With this plugin we want to retrieve the artifact from the previous step.