### PR TITLE
OMR: Remove old aarch64 Mac Machine

### DIFF
--- a/instances/technology.omr/jenkins/configuration.yml
+++ b/instances/technology.omr/jenkins/configuration.yml
@@ -79,17 +79,6 @@ jenkins:
         command:
           command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.omr jenkins@140.211.168.16 \"ssh -i ~/.ssh/id_rsa.aix omr@192.168.10.170 'wget -qO remoting.jar https://ci.eclipse.org/omr/jnlpJars/remoting.jar ; java  -jar remoting.jar'\""
   - permanent:
-      name: "mac13-aarch64-08"
-      nodeDescription: "OSX aarch64"
-      labelString: "OSX aarch64 UNB compile:amac"
-      remoteFS: '/Users/omr'
-      numExecutors: 1
-      mode: EXCLUSIVE
-      retentionStrategy: "always"
-      launcher:
-        command:
-          command: "ssh -C -i /run/secrets/jenkins/ssh/id_rsa.omr jenkins@140.211.168.16 \"ssh -i ~/.ssh/id_rsa.aix omr@192.168.10.177 'wget -qO remoting.jar https://ci.eclipse.org/omr/jnlpJars/remoting.jar ; java -Xmx1g -Xdump:system:none -Xdump:heap:none -Xdump:java:none -Xdump:snap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -Xdump:java:events=gpf+user+abort+traceassert+corruptcache -Xdump:snap:events=gpf+abort+traceassert+corruptcache -jar remoting.jar'\""
-  - permanent:
       name: "proxy"
       nodeDescription: "Used to connect to the UNB machines"
       labelString: "worker"


### PR DESCRIPTION
- remove mac13-aarch64-08

Signed-off-by: Aswin K R <aswinkr77@gmail.com>

Already provided Mac 15 replacements: https://github.com/eclipse-cbi/jiro/pull/433 & https://github.com/eclipse-cbi/jiro/pull/439 and they are running fine.

cc: @AdamBrousseau 