### PR TITLE
Central serverId entry in settings.xml for the OSSRH migration

### DIFF
--- a/templates/config.libsonnet
+++ b/templates/config.libsonnet
@@ -154,6 +154,14 @@ local clouds = import "clouds.libsonnet";
               pass: "bots/" + $.project.fullName + "/oss.sonatype.org/password",
             },
           },
+          central: {
+            username: {
+              pass: "bots/" + $.project.fullName + "/central.sonatype.org/token-username",
+            },
+            password: {
+              pass: "bots/" + $.project.fullName + "/central.sonatype.org/token-password",
+            },
+          },
           "gpg.passphrase": {
             passphrase: {
               pass: "bots/" + $.project.fullName + "/gpg/passphrase"


### PR DESCRIPTION
Add a new entry in settings.xml with the server ID: central.

The username and password are token-based and are generated from Central Portal account.