### PR TITLE
omr, justj: move from riscv-build1 to scaleway-riscv-build3

### DIFF
--- a/instances/technology.justj/jenkins/configuration.yml
+++ b/instances/technology.justj/jenkins/configuration.yml
@@ -70,7 +70,7 @@ jenkins:
       remoteFS: "/home/justj/build"
       retentionStrategy: "always"
   - permanent:
-      name: "riscv-build1"
+      name: "riscv-build3"
       nodeDescription: "4-core 8Gb riscv machine hosted by EF"
       labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
       remoteFS: '/home/jenkins/agent'
@@ -79,7 +79,7 @@ jenkins:
       retentionStrategy: "always"
       launcher:
         ssh:
-          host: "172.30.206.102"
+          host: "62.210.163.101"
           port: "2023"
           credentialsId: "jenkins-riscv-ssh"
           prefixStartSlaveCmd: "ulimit -c 0 && "
@@ -87,7 +87,7 @@ jenkins:
           jvmOptions: "-XX:-HeapDumpOnOutOfMemoryError -XX:-CreateCoredumpOnCrash"
           sshHostKeyVerificationStrategy:
             manuallyProvidedKeyVerificationStrategy:
-              key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbLax/0+MYc9YKExW50sK2ulFdJBme6QqE7y/AcELzI"
+              key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJG9E2uspGY1szNEq6Cl0nR6Gpa+1NpixcQzGLV7b2CF"
   - permanent:
       labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64 aarch64 arm64"
       launcher:

--- a/instances/technology.justj/target/config.json
+++ b/instances/technology.justj/target/config.json
@@ -575,15 +575,6 @@
                      "pass": "bots/technology.justj/gpg/passphrase"
                   }
                },
-               "ossrh": {
-                  "nexusProUrl": "https://oss.sonatype.org",
-                  "password": {
-                     "pass": "bots/technology.justj/oss.sonatype.org/password"
-                  },
-                  "username": {
-                     "pass": "bots/technology.justj/oss.sonatype.org/username"
-                  }
-               },
                "repo.eclipse.org": {
                   "password": {
                      "pass": "nexus/password"

--- a/instances/technology.justj/target/jenkins/configuration.yml
+++ b/instances/technology.justj/target/jenkins/configuration.yml
@@ -433,7 +433,7 @@ jenkins:
         remoteFS: "/home/justj/build"
         retentionStrategy: "always"
     - permanent:
-        name: "riscv-build1"
+        name: "riscv-build3"
         nodeDescription: "4-core 8Gb riscv machine hosted by EF"
         labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
         remoteFS: '/home/jenkins/agent'
@@ -442,7 +442,7 @@ jenkins:
         retentionStrategy: "always"
         launcher:
           ssh:
-            host: "172.30.206.102"
+            host: "62.210.163.101"
             port: "2023"
             credentialsId: "jenkins-riscv-ssh"
             prefixStartSlaveCmd: "ulimit -c 0 && "
@@ -450,7 +450,7 @@ jenkins:
             jvmOptions: "-XX:-HeapDumpOnOutOfMemoryError -XX:-CreateCoredumpOnCrash"
             sshHostKeyVerificationStrategy:
               manuallyProvidedKeyVerificationStrategy:
-                key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbLax/0+MYc9YKExW50sK2ulFdJBme6QqE7y/AcELzI"
+                key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJG9E2uspGY1szNEq6Cl0nR6Gpa+1NpixcQzGLV7b2CF"
     - permanent:
         labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64 aarch64 arm64"
         launcher:
@@ -743,8 +743,17 @@ tool:
                     url: "https://download.eclipse.org/cbi/build-tools/apache-ant-1.10.15-bin.zip"
   maven:
     installations:
+      - name: "maven-daemon"
+        properties:
+          - installSource:
+              installers:
+                - zip:
+                    subdir: "maven-mvnd-1.0.2-linux-amd64"
+                    url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
       - name: "apache-maven-latest"
         home: "/opt/tools/apache-maven/latest"
+      - name: "apache-maven-3.9.11"
+        home: "/opt/tools/apache-maven/3.9.11"
       - name: "apache-maven-3.9.9"
         home: "/opt/tools/apache-maven/3.9.9"
       - name: "apache-maven-3.9.6"
@@ -781,13 +790,6 @@ tool:
         home: "/opt/tools/apache-maven/3.3.9"
       - name: "apache-maven-3.2.5"
         home: "/opt/tools/apache-maven/3.2.5"
-      - name: "maven-daemon"
-        properties:
-          - installSource:
-              installers:
-                - zip:
-                    subdir: "maven-mvnd-1.0.2-linux-amd64"
-                    url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
   git:
     installations:
       - name: "Default"

--- a/instances/technology.justj/target/k8s/configmap-jenkins-config.yml
+++ b/instances/technology.justj/target/k8s/configmap-jenkins-config.yml
@@ -456,7 +456,7 @@ data:
             remoteFS: "/home/justj/build"
             retentionStrategy: "always"
         - permanent:
-            name: "riscv-build1"
+            name: "riscv-build3"
             nodeDescription: "4-core 8Gb riscv machine hosted by EF"
             labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
             remoteFS: '/home/jenkins/agent'
@@ -465,7 +465,7 @@ data:
             retentionStrategy: "always"
             launcher:
               ssh:
-                host: "172.30.206.102"
+                host: "62.210.163.101"
                 port: "2023"
                 credentialsId: "jenkins-riscv-ssh"
                 prefixStartSlaveCmd: "ulimit -c 0 && "
@@ -473,7 +473,7 @@ data:
                 jvmOptions: "-XX:-HeapDumpOnOutOfMemoryError -XX:-CreateCoredumpOnCrash"
                 sshHostKeyVerificationStrategy:
                   manuallyProvidedKeyVerificationStrategy:
-                    key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbLax/0+MYc9YKExW50sK2ulFdJBme6QqE7y/AcELzI"
+                    key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJG9E2uspGY1szNEq6Cl0nR6Gpa+1NpixcQzGLV7b2CF"
         - permanent:
             labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64 aarch64 arm64"
             launcher:
@@ -766,8 +766,17 @@ data:
                         url: "https://download.eclipse.org/cbi/build-tools/apache-ant-1.10.15-bin.zip"
       maven:
         installations:
+          - name: "maven-daemon"
+            properties:
+              - installSource:
+                  installers:
+                    - zip:
+                        subdir: "maven-mvnd-1.0.2-linux-amd64"
+                        url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
           - name: "apache-maven-latest"
             home: "/opt/tools/apache-maven/latest"
+          - name: "apache-maven-3.9.11"
+            home: "/opt/tools/apache-maven/3.9.11"
           - name: "apache-maven-3.9.9"
             home: "/opt/tools/apache-maven/3.9.9"
           - name: "apache-maven-3.9.6"
@@ -804,13 +813,6 @@ data:
             home: "/opt/tools/apache-maven/3.3.9"
           - name: "apache-maven-3.2.5"
             home: "/opt/tools/apache-maven/3.2.5"
-          - name: "maven-daemon"
-            properties:
-              - installSource:
-                  installers:
-                    - zip:
-                        subdir: "maven-mvnd-1.0.2-linux-amd64"
-                        url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
       git:
         installations:
           - name: "Default"

--- a/instances/technology.omr/jenkins/configuration.yml
+++ b/instances/technology.omr/jenkins/configuration.yml
@@ -537,7 +537,7 @@ jenkins:
             key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"            
 
   - permanent:
-      name: "riscv-build1"
+      name: "riscv-build3"
       nodeDescription: "4-core 8Gb riscv machine hosted by EF"
       labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
       remoteFS: '/home/jenkins'
@@ -546,12 +546,12 @@ jenkins:
       retentionStrategy: "always"
       launcher:
         ssh:
-          host: "172.30.206.102"
+          host: "62.210.163.101"
           port: "2024"
           credentialsId: "jenkins-riscv-ssh"
           javaPath: "/usr/bin/java"
           jvmOptions: ""
           sshHostKeyVerificationStrategy:
             manuallyProvidedKeyVerificationStrategy:
-              key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3NfgRdVq3ANypyHdvsx1RgrfirQqIg44kyFWzYjcIl"
+              key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEJf9y1GE0yXLWK2aR0On8ZkefDh8J9zuLMu5ads3CBl"
 

--- a/instances/technology.omr/target/config.json
+++ b/instances/technology.omr/target/config.json
@@ -650,15 +650,6 @@
                      "pass": "bots/technology.omr/gpg/passphrase"
                   }
                },
-               "ossrh": {
-                  "nexusProUrl": "https://oss.sonatype.org",
-                  "password": {
-                     "pass": "bots/technology.omr/oss.sonatype.org/password"
-                  },
-                  "username": {
-                     "pass": "bots/technology.omr/oss.sonatype.org/username"
-                  }
-               },
                "repo.eclipse.org": {
                   "password": {
                      "pass": "nexus/password"

--- a/instances/technology.omr/target/jenkins/configuration.yml
+++ b/instances/technology.omr/target/jenkins/configuration.yml
@@ -953,7 +953,7 @@ jenkins:
                 - home: '/opt/freeware/bin/git'
                   key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
     - permanent:
-        name: "riscv-build1"
+        name: "riscv-build3"
         nodeDescription: "4-core 8Gb riscv machine hosted by EF"
         labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
         remoteFS: '/home/jenkins'
@@ -962,14 +962,14 @@ jenkins:
         retentionStrategy: "always"
         launcher:
           ssh:
-            host: "172.30.206.102"
+            host: "62.210.163.101"
             port: "2024"
             credentialsId: "jenkins-riscv-ssh"
             javaPath: "/usr/bin/java"
             jvmOptions: ""
             sshHostKeyVerificationStrategy:
               manuallyProvidedKeyVerificationStrategy:
-                key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3NfgRdVq3ANypyHdvsx1RgrfirQqIg44kyFWzYjcIl"
+                key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEJf9y1GE0yXLWK2aR0On8ZkefDh8J9zuLMu5ads3CBl"
 security:
   apiToken:
     creationOfLegacyTokenEnabled: false
@@ -1240,8 +1240,17 @@ tool:
                     url: "https://download.eclipse.org/cbi/build-tools/apache-ant-1.10.15-bin.zip"
   maven:
     installations:
+      - name: "maven-daemon"
+        properties:
+          - installSource:
+              installers:
+                - zip:
+                    subdir: "maven-mvnd-1.0.2-linux-amd64"
+                    url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
       - name: "apache-maven-latest"
         home: "/opt/tools/apache-maven/latest"
+      - name: "apache-maven-3.9.11"
+        home: "/opt/tools/apache-maven/3.9.11"
       - name: "apache-maven-3.9.9"
         home: "/opt/tools/apache-maven/3.9.9"
       - name: "apache-maven-3.9.6"
@@ -1278,13 +1287,6 @@ tool:
         home: "/opt/tools/apache-maven/3.3.9"
       - name: "apache-maven-3.2.5"
         home: "/opt/tools/apache-maven/3.2.5"
-      - name: "maven-daemon"
-        properties:
-          - installSource:
-              installers:
-                - zip:
-                    subdir: "maven-mvnd-1.0.2-linux-amd64"
-                    url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
   git:
     installations:
       - name: "Default"

--- a/instances/technology.omr/target/k8s/configmap-jenkins-config.yml
+++ b/instances/technology.omr/target/k8s/configmap-jenkins-config.yml
@@ -976,7 +976,7 @@ data:
                     - home: '/opt/freeware/bin/git'
                       key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
         - permanent:
-            name: "riscv-build1"
+            name: "riscv-build3"
             nodeDescription: "4-core 8Gb riscv machine hosted by EF"
             labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
             remoteFS: '/home/jenkins'
@@ -985,14 +985,14 @@ data:
             retentionStrategy: "always"
             launcher:
               ssh:
-                host: "172.30.206.102"
+                host: "62.210.163.101"
                 port: "2024"
                 credentialsId: "jenkins-riscv-ssh"
                 javaPath: "/usr/bin/java"
                 jvmOptions: ""
                 sshHostKeyVerificationStrategy:
                   manuallyProvidedKeyVerificationStrategy:
-                    key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3NfgRdVq3ANypyHdvsx1RgrfirQqIg44kyFWzYjcIl"
+                    key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEJf9y1GE0yXLWK2aR0On8ZkefDh8J9zuLMu5ads3CBl"
     security:
       apiToken:
         creationOfLegacyTokenEnabled: false
@@ -1263,8 +1263,17 @@ data:
                         url: "https://download.eclipse.org/cbi/build-tools/apache-ant-1.10.15-bin.zip"
       maven:
         installations:
+          - name: "maven-daemon"
+            properties:
+              - installSource:
+                  installers:
+                    - zip:
+                        subdir: "maven-mvnd-1.0.2-linux-amd64"
+                        url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
           - name: "apache-maven-latest"
             home: "/opt/tools/apache-maven/latest"
+          - name: "apache-maven-3.9.11"
+            home: "/opt/tools/apache-maven/3.9.11"
           - name: "apache-maven-3.9.9"
             home: "/opt/tools/apache-maven/3.9.9"
           - name: "apache-maven-3.9.6"
@@ -1301,13 +1310,6 @@ data:
             home: "/opt/tools/apache-maven/3.3.9"
           - name: "apache-maven-3.2.5"
             home: "/opt/tools/apache-maven/3.2.5"
-          - name: "maven-daemon"
-            properties:
-              - installSource:
-                  installers:
-                    - zip:
-                        subdir: "maven-mvnd-1.0.2-linux-amd64"
-                        url: "https://download.eclipse.org/cbi/build-tools/maven-mvnd-1.0.2-linux-amd64.tar.gz"
       git:
         installations:
           - name: "Default"


### PR DESCRIPTION
Related to: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6626