### PR TITLE
Remove outdated tools from permanent nodes in RelEng instance

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -54,12 +54,6 @@ jenkins:
             value: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools'
       - toolLocation:
           locations:
-          - home: 'C:\ProgramData\chocolatey\lib\maven\apache-maven-3.8.1\bin\mvn.cmd'
-            key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@apache-maven-latest"
-          - home: 'C:\ProgramData\chocolatey\bin\ant.bat'
-            key: "hudson.tasks.Ant$AntInstallation$DescriptorImpl@apache-ant-1.9.6"
-          - home: 'C:\Program Files\AdoptOpenJDK\jdk-11.0.11.9-hotspot'
-            key: "hudson.model.JDK$DescriptorImpl@openjdk-jdk11-latest"
           - home: 'C:\Program Files\Git\bin\git'
             key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
   - permanent:
@@ -80,14 +74,6 @@ jenkins:
             manuallyProvidedKeyVerificationStrategy:
               key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC6tfKfT8YiNcb3WQOO2t4AmMEGsq+IhxAo2ROEXYrcYDJNWiR7jI4drW1jlOICQKqN5EcvBmTAUegHWuUVE+EVAQm9HrqFtAkJ7bhCcAUTtoMqdYzIR6vQ0LKCMsw6KuGVqsZ2Ub2pkA7CCbJE0CEX5uQFRFd57ngn5+kOJ4TcM9x8N7dEXyIv0lgos9J9JEm/XAlLfsdPomi79KcAE4DTWPkMCgs91aTzTRylIb0iEeReTSljw0UyWdsZgwPEX3ISUM+dWA0nl4W/lyeiEjD8r8EWx8h7POZXlMyYuwysbatrU8hfUlGoLKEKLuzozMfJCgW/v7gITU8J5pXCs4hV1lynM1G0avGnNWBrdeX+PW8abKK015/OZ+28Lt9+ig+BQtIF0S3AcUzzDPTjz1CpO0pq1dh2A2ed5RwHSg18CGzU17s4rnbBsNqZyB34NoUMEb0Lfs2ozucfXsasIhbtTqoo08LopcHagYx0VOHrYv3PPjOEemROmMPiU2xc1i8="
       nodeProperties:
-      - toolLocation:
-          locations:
-          - home: '/usr/bin/ant'
-            key: "hudson.tasks.Ant$AntInstallation$DescriptorImpl@apache-ant-1.9.6"
-          - home: '/usr/bin/mvn'
-            key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@apache-maven-latest"
-          - home: '/usr/bin/java'
-            key: "hudson.model.JDK$DescriptorImpl@openjdk-latest"
       - watcher:
           offlineAddresses: "releng@eclipse.org"
           onlineAddresses: "releng@eclipse.org"
@@ -193,12 +179,6 @@ jenkins:
               key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2EUBUJSBAIzhw5Vc1B/nIwWNWix+4Co8xtYGOJjEPP"
       mode: EXCLUSIVE
       nodeProperties:
-      - toolLocation:
-          locations:
-          - home: "/usr/local/openjdk-17/Contents/Home/bin"
-            key: "hudson.model.JDK$DescriptorImpl@openjdk-jdk17-latest"
-          - home: "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home/bin"
-            key: "hudson.model.JDK$DescriptorImpl@adoptopenjdk-hotspot-jdk11-latest"
       remoteFS: "/Users/genie.releng/"
       retentionStrategy: "always"
   - permanent:
@@ -219,8 +199,6 @@ jenkins:
           onlineAddresses: "releng@eclipse.org"
       - toolLocation:
           locations:
-          - home: "C:\\ProgramData\\chocolatey\\lib\\ant\\tools\\apache-ant-1.10.13"
-            key: "hudson.tasks.Ant$AntInstallation$DescriptorImpl@apache-ant-latest"
           - home: 'C:\Program Files\Git\bin\git'
             key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"
       remoteFS: "C:\\Users\\genie.releng\\"


### PR DESCRIPTION
The static JDK, Maven and ANT tools are outdated and not used. For some (i.e. ANT) dynamically installed alternative exists, that are better to use.

Relates to
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6653

@fredg02, @heurtematte or @pstankie could you please review and apply this ASAP as the Windows node is currently broken, because it tries to use the already removed ANT installation