### PR TITLE
Remove leftover nodeProperties key from RelEng JIPP's permanent nodes

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -178,7 +178,6 @@ jenkins:
             manuallyProvidedKeyVerificationStrategy:
               key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2EUBUJSBAIzhw5Vc1B/nIwWNWix+4Co8xtYGOJjEPP"
       mode: EXCLUSIVE
-      nodeProperties:
       remoteFS: "/Users/genie.releng/"
       retentionStrategy: "always"
   - permanent:


### PR DESCRIPTION
This was forgotten in
- https://github.com/eclipse-cbi/jiro/pull/485

It doesn't seem to be harmful but is unnecessary.