### PR TITLE
Add temurin-compliance Jenkins NodeMonitor config

### DIFF
--- a/instances/adoptium.temurin-compliance/jenkins/configuration.yml
+++ b/instances/adoptium.temurin-compliance/jenkins/configuration.yml
@@ -9,6 +9,13 @@ tool:
       home: ""
 
 jenkins:
+  nodeMonitors:
+    - "architecture"
+    - diskSpace:
+        freeSpaceThreshold: "10GB"
+    - "swapSpace"
+    - tmpSpace:
+        freeSpaceThreshold: "1GB"
   nodes:
   - permanent:
       name: "jck-marist-ubuntu2204-s390x-1"


### PR DESCRIPTION
To help monitor and prevent test failures due to low disk space, add Jenkins NodeMonitor with freeSpaceThreshold set to 10 Gb.
