### PR TITLE
Remove now unnecessary swt.natives agent labels from RelEng JIPP

### DIFF
--- a/instances/eclipse.platform.releng/jenkins/configuration.yml
+++ b/instances/eclipse.platform.releng/jenkins/configuration.yml
@@ -3,7 +3,7 @@ jenkins:
   - permanent:
       name: "b9h15-macos15-x86_64"
       nodeDescription: "macOS 15 (Sequoia 15.7.4), no login session, hosted on MacStadium"
-      labelString: "macos macos-15 swt.natives-cocoa.macosx.x86_64 native.builder-cocoa.macosx.x86_64"
+      labelString: "macos macos-15 native.builder-cocoa.macosx.x86_64"
       remoteFS: '/Users/genie.releng/jenkins_agent/'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -27,7 +27,7 @@ jenkins:
   - permanent:
       name: "rs68g-win10"
       nodeDescription: "Windows 10 Pro, hosted on Azure"
-      labelString: "windows swt.natives-win32.win32.x86_64 native.builder-win32.win32.x86_64"
+      labelString: "windows native.builder-win32.win32.x86_64"
       remoteFS: 'C:\Users\genie.releng\ci\'
       numExecutors: 1
       mode: EXCLUSIVE
@@ -79,7 +79,7 @@ jenkins:
           onlineAddresses: "releng@eclipse.org"
   - permanent:
       name: "ppcle-buildTest"
-      labelString: "ppctest ppcbuild swt.natives-gtk.linux.ppc64le native.builder-gtk.linux.ppc64le"
+      labelString: "ppctest ppcbuild native.builder-gtk.linux.ppc64le"
       remoteFS: "/home/swtbuild/build/"
       numExecutors: 1
       mode: EXCLUSIVE
@@ -107,7 +107,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-1"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build/"
       numExecutors: 1
@@ -122,7 +122,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-2"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build/"
       numExecutors: 1
@@ -137,7 +137,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-3"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build/"
       numExecutors: 1
@@ -152,7 +152,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "centos-aarch64-4"
-      labelString: "aarch64 arm64 swt.natives-gtk.linux.aarch64 native.builder-gtk.linux.aarch64"
+      labelString: "aarch64 arm64 native.builder-gtk.linux.aarch64"
       nodeDescription: "Agent provided by the project"
       remoteFS: "/home/swtbuild/build/"
       numExecutors: 1
@@ -167,7 +167,7 @@ jenkins:
             internalDir: "remoting"
   - permanent:
       name: "nc1ht-macos26-arm64"
-      labelString: "macos macos26 swt.natives-cocoa.macosx.aarch64 native.builder-cocoa.macosx.aarch64"
+      labelString: "macos macos26 native.builder-cocoa.macosx.aarch64"
       nodeDescription: "macOS Tahoe 26.4"
       launcher:
         ssh:
@@ -203,7 +203,7 @@ jenkins:
       remoteFS: "C:\\Users\\genie.releng\\"
       retentionStrategy: "always"
   - permanent:
-      labelString: "windows windows11 swt.natives-win32.win32.aarch64 native.builder-win32.win32.aarch64"
+      labelString: "windows windows11 native.builder-win32.win32.aarch64"
       launcher:
         inbound:
           webSocket: true
@@ -227,7 +227,7 @@ jenkins:
   - permanent:
       name: "riscv-build3"
       nodeDescription: "Scaleway hosted https://labs.scaleway.com/en/em-rv1/"
-      labelString: "hw.arch.riscv64 riscv64 swt.natives-gtk.linux.riscv64 native.builder-gtk.linux.riscv64"
+      labelString: "riscv64 native.builder-gtk.linux.riscv64"
       remoteFS: '/home/jenkins'
       numExecutors: 1
       mode: EXCLUSIVE


### PR DESCRIPTION
These labels were only used for a short time in an old version of the SWT Jenkinsfile and are unused for some time.
To keep it a little bit simpler, I suggest to remove them.

@pstankie, I suggest to apply this only after the new mac agents are added here in the context of [helpdesk#6621](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6621). Or before and the new agents are already added without these unused labels. As you prefer. I can also rebase this PR later, if necessary.