### PR TITLE
JDK tools of all LTS versions on all permanent agents of the RelEng JIPP

### DIFF
--- a/instances/eclipse.platform.releng/config.jsonnet
+++ b/instances/eclipse.platform.releng/config.jsonnet
@@ -17,7 +17,9 @@ local permissionsTemplates = import '../../templates/permissions.libsonnet';
       "job-dsl",
       "pipeline-graph-view",
       "pipeline-utility-steps",
+      "adoptopenjdk",
     ],
+    enableAutomaticTemurinJDKInstallations: true,
     staticAgentCount: 10,
     permissions+:
       permissionsTemplates.user("sravankumarl@in.ibm.com", ["Agent/Connect", "Agent/Disconnect"]) +

--- a/templates/config.libsonnet
+++ b/templates/config.libsonnet
@@ -32,6 +32,7 @@ local clouds = import "clouds.libsonnet";
     # see https://github.com/jenkinsci/docker/pull/577
     pluginsForceUpgrade: true,
     plugins: plugins.additionalPlugins($.project.fullName),
+    enableAutomaticTemurinJDKInstallations: false,
     permissions: permissions.projectPermissions($.project.unixGroupName,
       permissions.committerPermissionsList + if std.member($.jenkins.plugins, "gerrit-trigger") then ["Gerrit/ManualTrigger", "Gerrit/Retrigger",] else [])
       + permissions_extra.additionalPermissions($.project.fullName),

--- a/templates/jenkins/partials/tools-jdk.hbs
+++ b/templates/jenkins/partials/tools-jdk.hbs
@@ -89,7 +89,19 @@ jdk:
   - name: "temurin-latest"
     home: "/opt/tools/java/temurin/latest"
   - name: "temurin-jdk25-latest"
+{{#if jenkins.enableAutomaticTemurinJDKInstallations}}
+    properties:
+    - installSource:
+        installers:
+        - command:
+            command: "true"
+            label: "jdk-provider"
+            toolHome: "/opt/tools/java/temurin/jdk-25/latest"
+        - adoptOpenJdkInstaller:
+            id: "jdk-25.0.3+9"
+{{else}}
     home: "/opt/tools/java/temurin/jdk-25/latest"
+{{/if}}
   - name: "temurin-jdk24-latest"
     home: "/opt/tools/java/temurin/jdk-24/latest"
   - name: "temurin-jdk23-latest"
@@ -97,15 +109,63 @@ jdk:
   - name: "temurin-jdk22-latest"
     home: "/opt/tools/java/temurin/jdk-22/latest"
   - name: "temurin-jdk21-latest"
+{{#if jenkins.enableAutomaticTemurinJDKInstallations}}
+    properties:
+    - installSource:
+        installers:
+        - command:
+            command: "true"
+            label: "jdk-provider"
+            toolHome: "/opt/tools/java/temurin/jdk-21/latest"
+        - adoptOpenJdkInstaller:
+            id: "jdk-21.0.11+10"
+{{else}}
     home: "/opt/tools/java/temurin/jdk-21/latest"
+{{/if}}
   - name: "temurin-jdk20-latest"
     home: "/opt/tools/java/temurin/jdk-20/latest"
   - name: "temurin-jdk17-latest"
+{{#if jenkins.enableAutomaticTemurinJDKInstallations}}
+    properties:
+    - installSource:
+        installers:
+        - command:
+            command: "true"
+            label: "jdk-provider"
+            toolHome: "/opt/tools/java/temurin/jdk-17/latest"
+        - adoptOpenJdkInstaller:
+            id: "jdk-17.0.19+10"
+{{else}}
     home: "/opt/tools/java/temurin/jdk-17/latest"
+{{/if}}
   - name: "temurin-jdk11-latest"
+{{#if jenkins.enableAutomaticTemurinJDKInstallations}}
+    properties:
+    - installSource:
+        installers:
+        - command:
+            command: "true"
+            label: "jdk-provider"
+            toolHome: "/opt/tools/java/temurin/jdk-11/latest"
+        - adoptOpenJdkInstaller:
+            id: "jdk-11.0.31+11"
+{{else}}
     home: "/opt/tools/java/temurin/jdk-11/latest"
+{{/if}}
   - name: "temurin-jdk8-latest"
+{{#if jenkins.enableAutomaticTemurinJDKInstallations}}
+    properties:
+    - installSource:
+        installers:
+        - command:
+            command: "true"
+            label: "jdk-provider"
+            toolHome: "/opt/tools/java/temurin/jdk-8/latest"
+        - adoptOpenJdkInstaller:
+            id: "jdk8u492-b09"
+{{else}}
     home: "/opt/tools/java/temurin/jdk-8/latest"
+{{/if}}
   - name: "oracle-latest"
     home: "/opt/tools/java/oracle/latest"
   - name: "oracle-jdk10-latest"


### PR DESCRIPTION
Install the [adoptopenjdk](https://plugins.jenkins.io/adoptopenjdk/) Plug-in for the RelEng JIPP and configure it to act as fall-back `temurin-jdk` tool installer for the Java LTS versions 8, 11, 17, 21 and 25 as requested in:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7495

This is just an idea/concept proposal how I hope it could maybe work, but I have no experience if it really works and cannot verify it.

I also don't know how well this works in conjunction with the existing temurin-jdk definitions in `tools-jdk.hbs`:
https://github.com/eclipse-cbi/jiro/blob/16d90b87ff7ee8bb7888bf13375ea087294fc044/templates/jenkins/partials/tools-jdk.hbs#L91-L108

My assumption/hope is, that this overrides only the jdk-tools with the exact same name.
Furthermore I assume only if a new LTS version is released that we want to use on all agents in the RelEng JIPP we have to extend the list of tools defined in the RelEng's `configuration.yml`.

For continues updates of the defined adoptopenjdk jdk tools, i.e. to new builds of the same major version, one just has to update the corresponding exact label.
But I'm contemplating to suggest/contribute the ability to have a corresponding _latest_ label for each major version to the adoptopenj plugin.


Since I assume that the tools definition is global for the entire RelEng JIPP, I assume we have to add a label like `jdk-provider` to the provided default agents at:
- https://github.com/eclipse-cbi/jiro-agents/blob/e65111b89f27d2eea8664bda5c00be3f6831c63a/agents.jsonnet#L15
- https://github.com/eclipse-cbi/jiro-agents/blob/e65111b89f27d2eea8664bda5c00be3f6831c63a/agents.jsonnet#L28
- https://github.com/eclipse-cbi/jiro-agents/blob/e65111b89f27d2eea8664bda5c00be3f6831c63a/agents.jsonnet#L41

Or would it be possible to 'inject' the jdk-tool spec using `adoptopenjdk` only for the permanent agents defined here from one central location? Maybe using a dedicated hbs file? I'm not so familiar with all the configuration languages involved here and therefore can't tell in detail what's possible.
Then the entire fallback mechanism would not be necessary.